### PR TITLE
Fix changelog issues on debian jessie

### DIFF
--- a/data/scripts/pkg/debian/changelog
+++ b/data/scripts/pkg/debian/changelog
@@ -1,23 +1,23 @@
-cgrates (0.9.1-rc6) UNRELEASED; urgency=low
+cgrates (0.9.1~rc6) UNRELEASED; urgency=low
 
   * RC6.
 
  -- DanB <danb@cgrates.org>  Wednesday, 10 September 2014 13:30:00 +0100
 
-cgrates (0.9.1-rc5) UNRELEASED; urgency=low
+cgrates (0.9.1~rc5) UNRELEASED; urgency=low
 
   * RC5.
 
  -- DanB <danb@cgrates.org>  Monday, 18 August 2014 13:30:00 +0100
 
 
-cgrates (0.9.1-rc4) UNRELEASED; urgency=low
+cgrates (0.9.1~rc4) UNRELEASED; urgency=low
 
   * RC4.
 
  -- DanB <danb@cgrates.org>  Thursday, 25 March 2014 17:30:00 +0100
 
-cgrates (0.9.1-rc3) UNRELEASED; urgency=low
+cgrates (0.9.1~rc3) UNRELEASED; urgency=low
 
   * RC3.
 


### PR DESCRIPTION
Hi, 

In Debian Jessie version with **-** are not supported, so I replaced to **~**. 
 
The issue was:
```
dpkg-source: error: can't build with source format '3.0 (native)': native package version may not have a revision
dpkg-buildpackage: error: dpkg-source -b cgrates gave error exit status 255
```

Regards