### PR TITLE
Storage: Added jsonb support in cdrs_extra.extra_fields

### DIFF
--- a/data/storage/postgres/create_cdrs_tables.sql
+++ b/data/storage/postgres/create_cdrs_tables.sql
@@ -7,7 +7,7 @@ DROP TABLE IF EXISTS cdrs_primary;
 CREATE TABLE cdrs_primary (
   id SERIAL PRIMARY KEY,
   cgrid CHAR(40) NOT NULL,
-  tor  VARCHAR(16) NOT NULL, 
+  tor  VARCHAR(16) NOT NULL,
   accid VARCHAR(64) NOT NULL,
   cdrhost VARCHAR(64) NOT NULL,
   cdrsource VARCHAR(64) NOT NULL,
@@ -39,7 +39,7 @@ DROP TABLE IF EXISTS cdrs_extra;
 CREATE TABLE cdrs_extra (
   id SERIAL PRIMARY KEY,
   cgrid CHAR(40) NOT NULL,
-  extra_fields text NOT NULL,
+  extra_fields jsonb NOT NULL,
   created_at TIMESTAMP,
   deleted_at TIMESTAMP,
   UNIQUE (cgrid)


### PR DESCRIPTION
Hi, 

Extra_info are now saving into PostgreSQL database as text. PostgreSQL 9.4+ support native json support, so it's easy to make specified queries in the database using json. 

No changes in the code, Jsonb queries are the same as a text. 

About Jsonb in PostgreSQL:
- Datatypes: http://www.postgresql.org/docs/9.4/static/datatype-json.html
- Functions: http://www.postgresql.org/docs/9.4/static/functions-json.html

PS: PostgreSQL version in Debian stable is 9.4