### PR TITLE
ActionsTriggers: Metrics in call_url* functions

### DIFF
--- a/engine/action.go
+++ b/engine/action.go
@@ -486,7 +486,7 @@ func mailAsync(ub *Account, sq *StatsQueueTriggered, a *Action, acs Actions) err
 		message = []byte(fmt.Sprintf("To: %s\r\nSubject: [CGR Notification] Threshold hit on Balance: %s\r\n\r\nTime: \r\n\t%s\r\n\r\nBalance:\r\n\t%s\r\n\r\nYours faithfully,\r\nCGR Balance Monitor\r\n", toAddrStr, ub.Id, time.Now(), balJsn))
 	} else if sq != nil {
 		message = []byte(fmt.Sprintf("To: %s\r\nSubject: [CGR Notification] Threshold hit on StatsQueueId: %s\r\n\r\nTime: \r\n\t%s\r\n\r\nStatsQueueId:\r\n\t%s\r\n\r\nMetrics:\r\n\t%+v\r\n\r\nTrigger:\r\n\t%+v\r\n\r\nYours faithfully,\r\nCGR CDR Stats Monitor\r\n",
-			toAddrStr, sq.Id, time.Now(), sq.Id, sq.metrics, sq.Trigger))
+			toAddrStr, sq.Id, time.Now(), sq.Id, sq.Metrics, sq.Trigger))
 	}
 	auth := smtp.PlainAuth("", cgrCfg.MailerAuthUser, cgrCfg.MailerAuthPass, strings.Split(cgrCfg.MailerServer, ":")[0]) // We only need host part, so ignore port
 	go func() {

--- a/engine/stats_queue.go
+++ b/engine/stats_queue.go
@@ -215,12 +215,12 @@ func (sq *StatsQueue) GetId() string {
 
 // Convert data into a struct which can be used in actions based on triggers hit
 func (sq *StatsQueue) Triggered(at *ActionTrigger) *StatsQueueTriggered {
-	return &StatsQueueTriggered{Id: sq.conf.Id, metrics: sq.getStats(), Trigger: at}
+	return &StatsQueueTriggered{Id: sq.conf.Id, Metrics: sq.getStats(), Trigger: at}
 }
 
 // Struct to be passed to triggered actions
 type StatsQueueTriggered struct {
 	Id      string // StatsQueueId
-	metrics map[string]float64
+	Metrics map[string]float64
 	Trigger *ActionTrigger
 }


### PR DESCRIPTION
Hi, 

StatsQueueTriggered struct has metric key as internal value. When the system call to call_url or call_url_async, metrics key was not in the Json object, so 3-party applications doesn't know the current value of these metrics.

I added Metrics as public value and update the actions when metrics are called. 

On the other hand, this only affects to the Trigger struct, so in case of StatsQueue use metrics key as normal. 

With this changes, the call_url object it's like this: 

```json
{
  "Id": "LIMIT_XXXX",
  "Metrics": {
    "TCC": 2206.9265959989
  },
  "Trigger": {
    "ActionsId": "REPORT_LIMIT",
    "BalanceCategory": "",
    "BalanceDestinationIds": "",
    "BalanceDirection": "",
    "BalanceExpirationDate": "0001-01-01T00:00:00Z",
    "BalanceId": "",
    "BalanceRatingSubject": "",
    "BalanceSharedGroup": "",
    "BalanceTimingTags": "",
    "BalanceType": "",
    "BalanceWeight": 0,
    "Executed": false,
    "Id": "f2663a3f-579a-4edd-8119-9a13b9860f57",
    "MinQueuedItems": 0,
    "MinSleep": 900000000000,
    "Recurrent": true,
    "ThresholdType": "*max_tcc",
    "ThresholdValue": 2000,
    "Weight": 10
  }
}
```

Cheers. 