### PR TITLE
Issue #234: Added http_json on cdrs_replication

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -676,6 +676,9 @@ func (self *CGRConfig) loadFromJsonCfg(jsnCfg *CgrJsonCfg) error {
 				}
 				if rplJsonCfg.Attempts != nil {
 					self.CDRSCdrReplication[idx].Attempts = *rplJsonCfg.Attempts
+				} else {
+					// Use 1 as default. If not the cdr will never send
+					self.CDRSCdrReplication[idx].Attempts = 1
 				}
 				if rplJsonCfg.Cdr_filter != nil {
 					if self.CDRSCdrReplication[idx].CdrFilter, err = utils.ParseRSRFields(*rplJsonCfg.Cdr_filter, utils.INFIELD_SEP); err != nil {

--- a/config/libconfig.go
+++ b/config/libconfig.go
@@ -19,9 +19,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 package config
 
 import (
-	"time"
-
+	"fmt"
 	"github.com/cgrates/cgrates/utils"
+	"net/url"
+	"time"
 )
 
 type CdrReplicationCfg struct {
@@ -30,6 +31,15 @@ type CdrReplicationCfg struct {
 	Synchronous bool
 	Attempts    int             // Number of attempts if not success
 	CdrFilter   utils.RSRFields // Only replicate if the filters here are matching
+}
+
+func (rplCfg CdrReplicationCfg) GetFallbackFileName() string {
+	serverName := url.QueryEscape(rplCfg.Server)
+
+	result := fmt.Sprintf("cdr_%s_%s_%s.form",
+		rplCfg.Transport,
+		serverName, utils.GenUUID())
+	return result
 }
 
 type SureTaxCfg struct {

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -205,6 +205,8 @@ const (
 	METATAG                      = "metatag"
 	HTTP_POST                    = "http_post"
 	META_HTTP_POST               = "*http_post"
+	META_HTTP_JSON               = "*http_json"
+	META_HTTP_TEXT               = "*http_text"
 	META_HTTP_JSONRPC            = "*http_jsonrpc"
 	NANO_MULTIPLIER              = 1000000000
 	CGR_AUTHORIZE                = "CGR_AUTHORIZE"


### PR DESCRIPTION
- Added http_post and http_text on Cdrs Replication
- Added as default 1 attemps in cdrs_replication (Old json version doesn't have this option)
- Added url scape on servername when file fallback is created. If not can't be created