### PR TITLE
small fix: log and function name

### DIFF
--- a/cmd/cgr-engine/cgr-engine.go
+++ b/cmd/cgr-engine/cgr-engine.go
@@ -472,7 +472,7 @@ func startCDRS(internalCdrSChan chan *engine.CdrServer, logDb engine.LogStorage,
 
 	cdrServer, _ := engine.NewCdrServer(cfg, cdrDb, raterConn, pubSubConn, usersConn, aliasesConn, statsConn)
 	utils.Logger.Info("Registering CDRS HTTP Handlers.")
-	cdrServer.RegisterHanlersToServer(server)
+	cdrServer.RegisterHandlersToServer(server)
 	utils.Logger.Info("Registering CDRS RPC service.")
 	cdrSrv := v1.CdrsV1{CdrSrv: cdrServer}
 	server.RpcRegister(&cdrSrv)

--- a/engine/cdrs.go
+++ b/engine/cdrs.go
@@ -84,7 +84,7 @@ func (self *CdrServer) Timezone() string {
 	return self.cgrCfg.DefaultTimezone
 }
 
-func (self *CdrServer) RegisterHanlersToServer(server *utils.Server) {
+func (self *CdrServer) RegisterHandlersToServer(server *utils.Server) {
 	cdrServer = self // Share the server object for handlers
 	server.RegisterHttpFunc("/cdr_http", cgrCdrHandler)
 	server.RegisterHttpFunc("/freeswitch_json", fsCdrHandler)

--- a/sessionmanager/fssessionmanager.go
+++ b/sessionmanager/fssessionmanager.go
@@ -340,7 +340,7 @@ func (sm *FSSessionManager) Shutdown() (err error) {
 	}
 	for i := 0; len(sm.sessions.getSessions()) > 0 && i < 20; i++ {
 		time.Sleep(100 * time.Millisecond) // wait for the hungup event to be fired
-		utils.Logger.Info(fmt.Sprintf("<SM-FreeSWITC> Shutdown waiting on sessions: %v", sm.sessions))
+		utils.Logger.Info(fmt.Sprintf("<SM-FreeSWITCH> Shutdown waiting on sessions: %v", sm.sessions))
 	}
 	return nil
 }


### PR DESCRIPTION
- sessionmanager/fssessionmanager.go : fix log
- cmd/cgr-engine/cgr-engine.go  : rename RegisterHanlersToServer to RegisterHandlersToServer
- engine/cdrs.go : rename RegisterHanlersToServer to RegisterHandlersToServer