### PR TITLE
Detect active single-leg channels

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,6 +39,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @nikbyte  | Nick Altmann |
 | @kjcsb1   | Cameron Beattie |
 | @rinor    | Rinor Hoxha |
+| @bhepp    | Brice Heppner |
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |
 -->

--- a/sessionmanager/fssessionmanager.go
+++ b/sessionmanager/fssessionmanager.go
@@ -376,7 +376,7 @@ func (sm *FSSessionManager) SyncSessions() error {
 			}
 			var stillActive bool
 			for _, fsAChan := range aChans {
-				if fsAChan["call_uuid"] == session.eventStart.GetUUID() { // Channel still active
+				if fsAChan["call_uuid"] == session.eventStart.GetUUID() || (fsAChan["call_uuid"] == "" && fsAChan["uuid"] == session.eventStart.GetUUID()) { // Channel still active
 					stillActive = true
 					break
 				}


### PR DESCRIPTION
Only bridged calls will have a non-empty `call_uuid` in `show channels`. There are some valid single-leg scenarios (conference calls for example), which are not billed properly at the moment, because such calls are incorrectly detected as inactive:
```
CGRateS[8509]: <SM-FreeSWITCH> Sync active channels, stale session detected, uuid: 3030f113-1d83-4e80-b304-7e7c50084b7e
```

This PR fixes it by checking the `uuid` variable in case the `call_uuid` is empty. If the call leg was to be bridged, its `call_uuid` will be set to the `uuid` anyway. They are not always equivalent though, that's why it has to be an additional check and only in case the `call_uuid` is not set.