### PR TITLE
Added mi_fifo module in tutorial

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -43,6 +43,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @noahmehl | Noah Mehl |
 | @elfranne | Tom Braarup Cuykens |
 | @rbarrabe | Régis Barrabé |
+| @Joonake  | Joonas Keskitalo |
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |
 -->

--- a/data/tutorials/kamevapi/kamailio/etc/kamailio/kamailio.cfg
+++ b/data/tutorials/kamevapi/kamailio/etc/kamailio/kamailio.cfg
@@ -51,7 +51,7 @@ loadmodule "json.so"
 loadmodule "dialog.so"
 loadmodule "xhttp.so"
 loadmodule "jsonrpc-s.so"
-
+loadmodule "mi_fifo.so"
 
 
 # ----------------- setting module-specific parameters ---------------
@@ -88,6 +88,9 @@ modparam("usrloc", "nat_bflag", FLB_NATB)
 # ----- htable params -----
 modparam("htable", "htable", "users=>size=8;")
 modparam("htable", "htable", "cgrconn=>size=1;")
+
+# ----- mi_fifo params -----
+modparam("mi_fifo", "fifo_name", "/var/run/kamailio/kamailio_fifo")
 
 ####### Routing Logic ########
 


### PR DESCRIPTION
Added mi_fifo module in the kamailio.cfg of the kamevapi tutorial in order to make kamctl to work.