### PR TITLE
empty_balance_context fix - missing dialplan type.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -46,6 +46,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @J0hnSteel | John Koce Steel |
 | @ewsamuels | Errol Samuels |
 | @razvancrainea | Răzvan Crainea |
+| @marcinkowalczyk | Marcin Kowalczyk |
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |
 -->

--- a/sessionmanager/fssessionmanager.go
+++ b/sessionmanager/fssessionmanager.go
@@ -276,7 +276,7 @@ func (sm *FSSessionManager) DisconnectSession(ev engine.Event, connId, notify st
 	}
 	if notify == INSUFFICIENT_FUNDS {
 		if len(sm.cfg.EmptyBalanceContext) != 0 {
-			if _, err := sm.conns[connId].SendApiCmd(fmt.Sprintf("uuid_transfer %s %s %s\n\n", ev.GetUUID(), ev.GetCallDestNr(utils.META_DEFAULT), sm.cfg.EmptyBalanceContext)); err != nil {
+			if _, err := sm.conns[connId].SendApiCmd(fmt.Sprintf("uuid_transfer %s %s XML %s\n\n", ev.GetUUID(), ev.GetCallDestNr(utils.META_DEFAULT), sm.cfg.EmptyBalanceContext)); err != nil {
 				utils.Logger.Err(fmt.Sprintf("<SM-FreeSWITCH> Could not transfer the call to empty balance context, error: <%s>, connId: %s", err.Error(), connId))
 				return err
 			}


### PR DESCRIPTION
There is an issue with empty_balance_context. On FS 1.6.7 transfer fails with No route to destination error.
When calling uuid_transfer api type of dialplan is missing so transfer cannot be executed.  Proper syntax for uuid transfer between contexts:

freeswitch@freeswitch> uuid_transfer
-USAGE: <uuid> [-bleg|-both] <dest-exten> [<dialplan>] [<context>]

This pull request adds XML in request.