### PR TITLE
Solves an issue where the upload of a CDR from CDRC to a local CDRS would cause…

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -47,6 +47,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @ewsamuels | Errol Samuels |
 | @razvancrainea | Răzvan Crainea |
 | @marcinkowalczyk | Marcin Kowalczyk |
+| @andmar | André Maricato |
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |
 -->

--- a/cdrc/cdrc.go
+++ b/cdrc/cdrc.go
@@ -206,7 +206,7 @@ func (self *Cdrc) processFile(filePath string) error {
 				utils.Logger.Info(fmt.Sprintf("<Cdrc> DryRun CDR: %+v", storedCdr))
 				continue
 			}
-			if err := self.cdrs.Call("CdrsV1.ProcessCdr", storedCdr, &reply); err != nil {
+			if err := self.cdrs.Call("CdrsV1.ProcessCDR", storedCdr, &reply); err != nil {
 				utils.Logger.Err(fmt.Sprintf("<Cdrc> Failed sending CDR, %+v, error: %s", storedCdr, err.Error()))
 			} else if reply != "OK" {
 				utils.Logger.Err(fmt.Sprintf("<Cdrc> Received unexpected reply for CDR, %+v, reply: %s", storedCdr, reply))


### PR DESCRIPTION
… a NOT_IMPLEMENTED error.

Example error output:

> \<Cdrc\> Failed sending CDR, {"CGRID":"61420b54d127fa5b5cf8a41bfea52ccc42c36576","RunID":"","OrderID":0,"OriginHost":"0.0.0.0","Source":"freeswitch_csv","OriginID":"d875c440-bbd4-4026-96da-d6104eeaae5d","ToR":"*voice","RequestType":"*pseudoprepaid","Direction":"*out","Tenant":"cgrates.org","Category":"call","Account":"1001","Subject":"1001","Destination":"3519","SetupTime":"2016-07-08T11:13:36+01:00","PDD":0,"AnswerTime":"0001-01-01T00:00:00Z","Usage":0,"Supplier":"","DisconnectCause":"","ExtraFields":{},"CostSource":"","Cost":-1,"CostDetails":null,"ExtraInfo":"","Rated":false}, error: NOT_IMPLEMENTED