### PR TITLE
Condition to update only triggers in cdrstats

### DIFF
--- a/engine/stats_queue.go
+++ b/engine/stats_queue.go
@@ -76,7 +76,7 @@ func (sq *StatsQueue) UpdateConf(conf *CdrStats) {
 	sq.mux.Lock()
 	defer sq.mux.Unlock()
 	// check if new conf asks for action trigger reset only
-	if sq.conf != nil && (!conf.hasGeneralConfigs() || sq.conf.equalExceptTriggers(conf)) {
+	if sq.conf != nil && (conf.hasGeneralConfigs() || sq.conf.equalExceptTriggers(conf)) {
 		sq.conf.Triggers = conf.Triggers
 		return
 	}


### PR DESCRIPTION
Before this correction, if we modify the conf of cdrstat, the modification will not be saved in memory. 
