### PR TITLE
small uuid fix

### DIFF
--- a/engine/balance_filter.go
+++ b/engine/balance_filter.go
@@ -293,6 +293,9 @@ func (bf *BalanceFilter) ModifyBalance(b *Balance) {
 	if b == nil {
 		return
 	}
+        if bf.Uuid != nil {
+		b.Uuid = *bf.Uuid
+	}
 	if bf.ID != nil {
 		b.ID = *bf.ID
 	}


### PR DESCRIPTION
Hello DanB I noticed that every time I use ApierV1.SetBalance with BalanceUUID , that value was ignored and utils.GenUUID() was used to create a new one.