### PR TITLE
CDRC: Fix issue with disabled cdrc clients

### DIFF
--- a/cmd/cgr-engine/cgr-engine.go
+++ b/cmd/cgr-engine/cgr-engine.go
@@ -96,7 +96,9 @@ func startCdrcs(internalCdrSChan, internalRaterChan chan rpcclient.RpcClientConn
 			}
 
 			if len(enabledCfgs) != 0 {
-				go startCdrc(internalCdrSChan, internalRaterChan, cdrcCfgs, cfg.HttpSkipTlsVerify, cdrcChildrenChan, exitChan)
+				go startCdrc(internalCdrSChan, internalRaterChan, enabledCfgs, cfg.HttpSkipTlsVerify, cdrcChildrenChan, exitChan)
+			} else {
+				utils.Logger.Info("<CDRC> No enabled CDRC clients")
 			}
 		}
 		cdrcInitialized = true // Initialized


### PR DESCRIPTION
Hey @danbogos 

This fix the problem if the ID is not *default and default is disabled didn't start and raise an error on process the CDR. 

On the other hand, added a log in case of no enable CDRC clients. 

Regards