### PR TITLE
Storage: Accounts fields length consistency

### DIFF
--- a/data/storage/mysql/create_tariffplan_tables.sql
+++ b/data/storage/mysql/create_tariffplan_tables.sql
@@ -130,7 +130,7 @@ CREATE TABLE `tp_shared_groups` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `tpid` varchar(64) NOT NULL,
   `tag` varchar(64) NOT NULL,
-  `account` varchar(24) NOT NULL,
+  `account` varchar(64) NOT NULL,
   `strategy` varchar(24) NOT NULL,
   `rating_subject` varchar(24) NOT NULL,
   `created_at` TIMESTAMP,
@@ -258,7 +258,7 @@ CREATE TABLE tp_lcr_rules (
   `direction` varchar(8) NOT NULL,
   `tenant` varchar(64) NOT NULL,
   `category` varchar(32) NOT NULL,
-  `account` varchar(24) NOT NULL,
+  `account` varchar(64) NOT NULL,
   `subject` varchar(64) NOT NULL,
   `destination_tag` varchar(64) NOT NULL,
   `rp_category` varchar(32) NOT NULL,
@@ -283,7 +283,7 @@ CREATE TABLE tp_derived_chargers (
   `direction` varchar(8) NOT NULL,
   `tenant` varchar(64) NOT NULL,
   `category` varchar(32) NOT NULL,
-  `account` varchar(24) NOT NULL,
+  `account` varchar(64) NOT NULL,
   `subject` varchar(64) NOT NULL,
   `destination_ids` varchar(64) NOT NULL,
   `runid`  varchar(24) NOT NULL,
@@ -292,8 +292,8 @@ CREATE TABLE tp_derived_chargers (
   `direction_field`  varchar(24) NOT NULL,
   `tenant_field`  varchar(24) NOT NULL,
   `category_field`  varchar(24) NOT NULL,
-  `account_field`  varchar(24) NOT NULL,
-  `subject_field`  varchar(24) NOT NULL,
+  `account_field`  varchar(64) NOT NULL,
+  `subject_field`  varchar(64) NOT NULL,
   `destination_field`  varchar(24) NOT NULL,
   `setup_time_field`  varchar(24) NOT NULL,
   `pdd_field`  varchar(24) NOT NULL,
@@ -330,7 +330,7 @@ CREATE TABLE tp_cdr_stats (
   `directions` varchar(8) NOT NULL,
   `tenants` varchar(64) NOT NULL,
   `categories` varchar(32) NOT NULL,
-  `accounts` varchar(24) NOT NULL,
+  `accounts` varchar(255) NOT NULL,
   `subjects` varchar(64) NOT NULL,
   `destination_ids` varchar(64) NOT NULL,
   `pdd_interval` varchar(64) NOT NULL,
@@ -338,7 +338,7 @@ CREATE TABLE tp_cdr_stats (
   `suppliers` varchar(64) NOT NULL,
   `disconnect_causes` varchar(64) NOT NULL,
   `mediation_runids` varchar(64) NOT NULL,
-  `rated_accounts` varchar(64) NOT NULL,
+  `rated_accounts` varchar(255) NOT NULL,
   `rated_subjects` varchar(64) NOT NULL,
   `cost_interval` varchar(24) NOT NULL,
   `action_triggers` varchar(64) NOT NULL,
@@ -408,6 +408,6 @@ CREATE TABLE tp_resource_limits (
   PRIMARY KEY (`id`),
   KEY `tpid` (`tpid`),
   UNIQUE KEY `unique_tp_resource_limits` (`tpid`, `tag`)
-);  
+);
 
 

--- a/data/storage/postgres/create_tariffplan_tables.sql
+++ b/data/storage/postgres/create_tariffplan_tables.sql
@@ -125,7 +125,7 @@ CREATE TABLE tp_shared_groups (
   id SERIAL PRIMARY KEY,
   tpid VARCHAR(64) NOT NULL,
   tag VARCHAR(64) NOT NULL,
-  account VARCHAR(24) NOT NULL,
+  account VARCHAR(64) NOT NULL,
   strategy VARCHAR(24) NOT NULL,
   rating_subject VARCHAR(24) NOT NULL,
   created_at TIMESTAMP,
@@ -253,7 +253,7 @@ CREATE TABLE tp_lcr_rules (
   direction VARCHAR(8) NOT NULL,
   tenant VARCHAR(64) NOT NULL,
   category VARCHAR(32) NOT NULL,
-  account VARCHAR(24) NOT NULL,
+  account VARCHAR(64) NOT NULL,
   subject VARCHAR(64) NOT NULL,
   destination_tag VARCHAR(64) NOT NULL,
   rp_category VARCHAR(32) NOT NULL,
@@ -278,7 +278,7 @@ CREATE TABLE tp_derived_chargers (
   direction VARCHAR(8) NOT NULL,
   tenant VARCHAR(64) NOT NULL,
   category VARCHAR(32) NOT NULL,
-  account VARCHAR(24) NOT NULL,
+  account VARCHAR(64) NOT NULL,
   subject VARCHAR(64) NOT NULL,
   destination_ids VARCHAR(64) NOT NULL,
   runid  VARCHAR(24) NOT NULL,
@@ -287,8 +287,8 @@ CREATE TABLE tp_derived_chargers (
   direction_field  VARCHAR(24) NOT NULL,
   tenant_field  VARCHAR(24) NOT NULL,
   category_field  VARCHAR(24) NOT NULL,
-  account_field  VARCHAR(24) NOT NULL,
-  subject_field  VARCHAR(24) NOT NULL,
+  account_field  VARCHAR(64) NOT NULL,
+  subject_field  VARCHAR(64) NOT NULL,
   destination_field  VARCHAR(24) NOT NULL,
   setup_time_field  VARCHAR(24) NOT NULL,
   pdd_field  VARCHAR(24) NOT NULL,
@@ -325,7 +325,7 @@ CREATE TABLE tp_cdr_stats (
   directions VARCHAR(8) NOT NULL,
   tenants VARCHAR(64) NOT NULL,
   categories VARCHAR(32) NOT NULL,
-  accounts VARCHAR(24) NOT NULL,
+  accounts VARCHAR(255) NOT NULL,
   subjects VARCHAR(64) NOT NULL,
   destination_ids VARCHAR(64) NOT NULL,
   pdd_interval VARCHAR(64) NOT NULL,
@@ -333,7 +333,7 @@ CREATE TABLE tp_cdr_stats (
   suppliers VARCHAR(64) NOT NULL,
   disconnect_causes VARCHAR(64) NOT NULL,
   mediation_runids VARCHAR(64) NOT NULL,
-  rated_accounts VARCHAR(64) NOT NULL,
+  rated_accounts VARCHAR(255) NOT NULL,
   rated_subjects VARCHAR(64) NOT NULL,
   cost_interval VARCHAR(24) NOT NULL,
   action_triggers VARCHAR(64) NOT NULL,
@@ -402,4 +402,4 @@ CREATE TABLE tp_resource_limits (
 );
 CREATE INDEX tp_resource_limits_idx ON tp_resource_limits (tpid);
 CREATE INDEX tp_resource_limits_unique ON tp_resource_limits  ("tpid", "tag");
- 
+


### PR DESCRIPTION
Hey, 

Today I was running some problems with the account names. In account actions the varchar length is 64, but in another places are 24. So I changed all to 64, like 24 is too small for account name. The same for subject. 

In the other hand, in cdr stats, I added 255, that stat is a rsr field. This value should be enough based on the regexp that we have. 

Regards. 