### PR TITLE
Missing spooldir directories in RPM build script

### DIFF
--- a/packages/redhat_fedora/cgrates.spec
+++ b/packages/redhat_fedora/cgrates.spec
@@ -88,6 +88,12 @@ mkdir -p $RPM_BUILD_ROOT%{_logdir}/cdrc/in
 mkdir -p $RPM_BUILD_ROOT%{_logdir}/cdrc/out
 mkdir -p $RPM_BUILD_ROOT%{_logdir}/cdre/csv
 mkdir -p $RPM_BUILD_ROOT%{_logdir}/cdre/fwv
+mkdir -p $RPM_BUILD_ROOT%{_spooldir}/cdrc/in
+mkdir -p $RPM_BUILD_ROOT%{_spooldir}/cdrc/out
+mkdir -p $RPM_BUILD_ROOT%{_spooldir}/cdre/csv
+mkdir -p $RPM_BUILD_ROOT%{_spooldir}/cdre/fwv
+mkdir -p $RPM_BUILD_ROOT%{_spooldir}/tpe
+mkdir -p $RPM_BUILD_ROOT%{_spooldir}/http_failed
 mkdir -p $RPM_BUILD_ROOT%{_libdir}/history
 mkdir -p $RPM_BUILD_ROOT%{_libdir}/cache_dump
 install -D -m 0644 -p src/github.com/cgrates/cgrates/packages/redhat_fedora/%{name}.options $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/%{name}


### PR DESCRIPTION
Hello,

I am getting an error with rpmbuild because spooldir directories are missing. Can you fix this with this patch?

```
[admin@server cgr_build]$ rpmbuild -bb --define "_topdir $HOME/cgr_build" SPECS/cgrates.spec
Exécution_de(%prep) : /bin/sh -e /var/tmp/rpm-tmp.oxMhbk
+ umask 022
+ cd /home/admin/cgr_build/BUILD
+ cd /home/admin/cgr_build/BUILD
+ rm -rf cgrates-0.9.1rc7.87e12f6
+ /usr/bin/mkdir -p cgrates-0.9.1rc7.87e12f6
+ cd cgrates-0.9.1rc7.87e12f6
+ /usr/bin/gzip -dc /home/admin/cgr_build/SOURCES/87e12f6ea4cc7656baca4002baa6af48fca0c6d4.tar.gz
+ /usr/bin/tar -xf -
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ /usr/bin/chmod -Rf a+rX,u+w,g-w,o-w .
+ mkdir -p src/github.com/cgrates
+ ln -sf ../../../cgrates-87e12f6ea4cc7656baca4002baa6af48fca0c6d4 src/github.com/cgrates/cgrates
+ exit 0
Exécution_de(%build) : /bin/sh -e /var/tmp/rpm-tmp.cT34vu
+ umask 022
+ cd /home/admin/cgr_build/BUILD
+ cd cgrates-0.9.1rc7.87e12f6
+ export GO15VENDOREXPERIMENT=1
+ GO15VENDOREXPERIMENT=1
+ export GOPATH=/home/admin/cgr_build/BUILD/cgrates-0.9.1rc7.87e12f6
+ GOPATH=/home/admin/cgr_build/BUILD/cgrates-0.9.1rc7.87e12f6
+ cd /home/admin/cgr_build/BUILD/cgrates-0.9.1rc7.87e12f6/src/github.com/cgrates/cgrates
+ go get -v github.com/Masterminds/glide
github.com/Masterminds/glide (download)
github.com/Masterminds/glide/vendor/github.com/Masterminds/vcs
github.com/Masterminds/glide/msg
github.com/Masterminds/glide/godep/strip
github.com/Masterminds/glide/path
github.com/Masterminds/glide/vendor/github.com/Masterminds/semver
github.com/Masterminds/glide/cache
github.com/Masterminds/glide/vendor/gopkg.in/yaml.v2
github.com/Masterminds/glide/mirrors
github.com/Masterminds/glide/util
github.com/Masterminds/glide/cfg
github.com/Masterminds/glide/dependency
github.com/Masterminds/glide/gb
github.com/Masterminds/glide/godep
github.com/Masterminds/glide/gom
github.com/Masterminds/glide/gpm
github.com/Masterminds/glide/importer
github.com/Masterminds/glide/vendor/github.com/codegangsta/cli
github.com/Masterminds/glide/repo
github.com/Masterminds/glide/tree
github.com/Masterminds/glide/action
github.com/Masterminds/glide
+ /home/admin/cgr_build/BUILD/cgrates-0.9.1rc7.87e12f6/bin/glide install
[WARN]  The name listed in the config file () does not match the current location (github.com/cgrates/cgrates)
[INFO]  Downloading dependencies. Please wait...
[INFO]  --> Found desired version locally github.com/cenk/hub 11382a9960d39b0ecda16fd01c424c11ff765a34!
[INFO]  --> Found desired version locally github.com/cenkalti/rpc2 7ab76d2e88c77ca1a715756036d8264b2886acd2!
[INFO]  --> Found desired version locally github.com/cgrates/fsock a8ffdbdfc8440016df008ba91e6f05f806d7a69f!
[INFO]  --> Found desired version locally github.com/cgrates/kamevapi a376b1f937ba959857929fa3e111c0f3243278c0!
[INFO]  --> Found desired version locally github.com/cgrates/osipsdagram 3d6beed663452471dec3ca194137a30d379d9e8f!
[INFO]  --> Found desired version locally github.com/cgrates/rpcclient 1d54b34b6a5531e1124728b489c44ec6a8ac231e!
[INFO]  --> Found desired version locally github.com/ChrisTrenkamp/goxpath 4aad8d0161aae7d17df4755d2c1e86cd1fcaaab6!
[INFO]  --> Found desired version locally github.com/DisposaBoy/JsonConfigReader 33a99fdf1d5ee1f79b5077e9c06f955ad356d5f4!
[INFO]  --> Found desired version locally github.com/fiorix/go-diameter 9ada6bfd077a36dc892676633a2c9ca42d884202!
[INFO]  --> Found desired version locally github.com/go-sql-driver/mysql 3654d25ec346ee8ce71a68431025458d52a38ac0!
[INFO]  --> Found desired version locally github.com/gorhill/cronexpr f0984319b44273e83de132089ae42b1810f4933b!
[INFO]  --> Found desired version locally github.com/hashicorp/golang-lru 0a025b7e63adc15a622f29b0b2c4c3848243bbf6!
[INFO]  --> Found desired version locally github.com/jinzhu/gorm 3324ab20633e8c7ec6d6b1f7a714a1a6e06fec08!
[INFO]  --> Found desired version locally github.com/jinzhu/inflection 8f4d3a0d04ce0b7c0cf3126fb98524246d00d102!
[INFO]  --> Found desired version locally github.com/kr/pty a6bad5ee6fc60cad43d219214dd2449bf077f3f5!
[INFO]  --> Found desired version locally github.com/lib/pq 4dd446efc17690bc53e154025146f73203b18309!
[INFO]  --> Found desired version locally github.com/mediocregopher/radix.v2 ae04b3eb3731f94789205d1268e0759371166605!
[INFO]  --> Found desired version locally github.com/mitchellh/mapstructure d2dd0262208475919e1a362f675cfc0e7c10e905!
[INFO]  --> Found desired version locally github.com/peterh/liner 8975875355a81d612fafb9f5a6037bdcc2d9b073!
[INFO]  --> Found desired version locally github.com/ugorji/go b94837a2404ab90efe9289e77a70694c355739cb!
[INFO]  --> Found desired version locally golang.org/x/net b400c2eff1badec7022a8c8f5bea058b6315eed7!
[INFO]  --> Found desired version locally golang.org/x/sys a408501be4d17ee978c04a618e7a1b22af058c0e!
[INFO]  --> Found desired version locally golang.org/x/text ce78b075c2fbd48520f4995b173eb9fe18b56ef3!
[INFO]  --> Found desired version locally gopkg.in/fsnotify.v1 a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb!
[INFO]  --> Found desired version locally gopkg.in/mgo.v2 29cc868a5ca65f401ff318143f9408d02f4799cc!
[INFO]  Setting references.
[INFO]  --> Setting version for github.com/cenk/hub to 11382a9960d39b0ecda16fd01c424c11ff765a34.
[INFO]  --> Setting version for github.com/cenkalti/rpc2 to 7ab76d2e88c77ca1a715756036d8264b2886acd2.
[INFO]  --> Setting version for github.com/cgrates/fsock to a8ffdbdfc8440016df008ba91e6f05f806d7a69f.
[INFO]  --> Setting version for github.com/cgrates/kamevapi to a376b1f937ba959857929fa3e111c0f3243278c0.
[INFO]  --> Setting version for github.com/cgrates/osipsdagram to 3d6beed663452471dec3ca194137a30d379d9e8f.
[INFO]  --> Setting version for github.com/cgrates/rpcclient to 1d54b34b6a5531e1124728b489c44ec6a8ac231e.
[INFO]  --> Setting version for github.com/ChrisTrenkamp/goxpath to 4aad8d0161aae7d17df4755d2c1e86cd1fcaaab6.
[INFO]  --> Setting version for github.com/DisposaBoy/JsonConfigReader to 33a99fdf1d5ee1f79b5077e9c06f955ad356d5f4.
[INFO]  --> Setting version for github.com/fiorix/go-diameter to 9ada6bfd077a36dc892676633a2c9ca42d884202.
[INFO]  --> Setting version for github.com/go-sql-driver/mysql to 3654d25ec346ee8ce71a68431025458d52a38ac0.
[INFO]  --> Setting version for github.com/gorhill/cronexpr to f0984319b44273e83de132089ae42b1810f4933b.
[INFO]  --> Setting version for github.com/hashicorp/golang-lru to 0a025b7e63adc15a622f29b0b2c4c3848243bbf6.
[INFO]  --> Setting version for github.com/jinzhu/gorm to 3324ab20633e8c7ec6d6b1f7a714a1a6e06fec08.
[INFO]  --> Setting version for github.com/jinzhu/inflection to 8f4d3a0d04ce0b7c0cf3126fb98524246d00d102.
[INFO]  --> Setting version for github.com/kr/pty to a6bad5ee6fc60cad43d219214dd2449bf077f3f5.
[INFO]  --> Setting version for github.com/lib/pq to 4dd446efc17690bc53e154025146f73203b18309.
[INFO]  --> Setting version for github.com/mediocregopher/radix.v2 to ae04b3eb3731f94789205d1268e0759371166605.
[INFO]  --> Setting version for github.com/mitchellh/mapstructure to d2dd0262208475919e1a362f675cfc0e7c10e905.
[INFO]  --> Setting version for github.com/peterh/liner to 8975875355a81d612fafb9f5a6037bdcc2d9b073.
[INFO]  --> Setting version for github.com/ugorji/go to b94837a2404ab90efe9289e77a70694c355739cb.
[INFO]  --> Setting version for golang.org/x/net to b400c2eff1badec7022a8c8f5bea058b6315eed7.
[INFO]  --> Setting version for golang.org/x/sys to a408501be4d17ee978c04a618e7a1b22af058c0e.
[INFO]  --> Setting version for golang.org/x/text to ce78b075c2fbd48520f4995b173eb9fe18b56ef3.
[INFO]  --> Setting version for gopkg.in/fsnotify.v1 to a8a77c9133d2d6fd8334f3260d06f60e8d80a5fb.
[INFO]  --> Setting version for gopkg.in/mgo.v2 to 29cc868a5ca65f401ff318143f9408d02f4799cc.
[INFO]  Exporting resolved dependencies...
[INFO]  --> Exporting github.com/cenk/hub
[INFO]  --> Exporting github.com/cenkalti/rpc2
[INFO]  --> Exporting github.com/cgrates/fsock
[INFO]  --> Exporting github.com/cgrates/kamevapi
[INFO]  --> Exporting github.com/cgrates/osipsdagram
[INFO]  --> Exporting github.com/cgrates/rpcclient
[INFO]  --> Exporting github.com/ChrisTrenkamp/goxpath
[INFO]  --> Exporting github.com/DisposaBoy/JsonConfigReader
[INFO]  --> Exporting github.com/fiorix/go-diameter
[INFO]  --> Exporting github.com/go-sql-driver/mysql
[INFO]  --> Exporting github.com/gorhill/cronexpr
[INFO]  --> Exporting github.com/jinzhu/gorm
[INFO]  --> Exporting github.com/jinzhu/inflection
[INFO]  --> Exporting github.com/kr/pty
[INFO]  --> Exporting github.com/lib/pq
[INFO]  --> Exporting github.com/mediocregopher/radix.v2
[INFO]  --> Exporting github.com/mitchellh/mapstructure
[INFO]  --> Exporting github.com/peterh/liner
[INFO]  --> Exporting github.com/ugorji/go
[INFO]  --> Exporting github.com/hashicorp/golang-lru
[INFO]  --> Exporting golang.org/x/net
[INFO]  --> Exporting golang.org/x/text
[INFO]  --> Exporting golang.org/x/sys
[INFO]  --> Exporting gopkg.in/fsnotify.v1
[INFO]  --> Exporting gopkg.in/mgo.v2
[INFO]  Replacing existing vendor dependencies
+ ./build.sh
Building CGRateS...
+ exit 0
Exécution_de(%install) : /bin/sh -e /var/tmp/rpm-tmp.qyBMTt
+ umask 022
+ cd /home/admin/cgr_build/BUILD
+ '[' /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64 '!=' / ']'
+ rm -rf /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64
++ dirname /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64
+ mkdir -p /home/admin/cgr_build/BUILDROOT
+ mkdir /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64
+ cd cgrates-0.9.1rc7.87e12f6
+ rm -rf /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64
+ mkdir -p /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/usr/share/cgrates
+ cp -rpf src/github.com/cgrates/cgrates/data/conf src/github.com/cgrates/cgrates/data/daemontools src/github.com/cgrates/cgrates/data/diameter src/github.com/cgrates/cgrates/data/docker src/github.com/cgrates/cgrates/data/freeswitch src/github.com/cgrates/cgrates/data/kamailio src/github.com/cgrates/cgrates/data/monit src/github.com/cgrates/cgrates/data/scripts src/github.com/cgrates/cgrates/data/storage src/github.com/cgrates/cgrates/data/tariffplans src/github.com/cgrates/cgrates/data/tester src/github.com/cgrates/cgrates/data/tutorials src/github.com/cgrates/cgrates/data/vagrant /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/usr/share/cgrates
+ install -D -m 0644 -p src/github.com/cgrates/cgrates/data/conf/cgrates/cgrates.json /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/etc/cgrates/cgrates.json
+ install -D -m 0755 -p bin/cgr-console /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/usr/bin/cgr-console
+ install -D -m 0755 -p bin/cgr-engine /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/usr/bin/cgr-engine
+ install -D -m 0755 -p bin/cgr-loader /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/usr/bin/cgr-loader
+ install -D -m 0755 -p bin/cgr-tester /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/usr/bin/cgr-tester
+ mkdir -p /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/var/log/cgrates/cdrc/in
+ mkdir -p /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/var/log/cgrates/cdrc/out
+ mkdir -p /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/var/log/cgrates/cdre/csv
+ mkdir -p /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/var/log/cgrates/cdre/fwv
+ mkdir -p /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/var/lib/cgrates/history
+ mkdir -p /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/var/lib/cgrates/cache_dump
+ install -D -m 0644 -p src/github.com/cgrates/cgrates/packages/redhat_fedora/cgrates.options /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/etc/sysconfig/cgrates
+ install -D -m 0644 -p src/github.com/cgrates/cgrates/packages/redhat_fedora/cgrates.service /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/usr/lib/systemd/system/cgrates.service
+ /usr/lib/rpm/check-buildroot
+ /usr/lib/rpm/redhat/brp-compress
+ /usr/lib/rpm/redhat/brp-strip /usr/bin/strip
+ /usr/lib/rpm/redhat/brp-strip-comment-note /usr/bin/strip /usr/bin/objdump
+ /usr/lib/rpm/redhat/brp-strip-static-archive /usr/bin/strip
+ /usr/lib/rpm/brp-python-bytecompile /usr/bin/python 1
+ /usr/lib/rpm/redhat/brp-python-hardlink
+ /usr/lib/rpm/redhat/brp-java-repack-jars
Traitement des fichiers : cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64
erreur : Fichier non trouvé par la substitution : /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/var/spool/cgrates/*

Erreur de construction de RPM :
    Fichier non trouvé par la substitution : /home/admin/cgr_build/BUILDROOT/cgrates-0.9.1rc7.87e12f6-1.el7.centos.x86_64/var/spool/cgrates/*
```