### PR TITLE
Escaping *

### DIFF
--- a/engine/storage_mongo_datadb.go
+++ b/engine/storage_mongo_datadb.go
@@ -679,7 +679,7 @@ func (ms *MongoStorage) SetRatingProfile(rp *RatingProfile, transactionID string
 func (ms *MongoStorage) RemoveRatingProfile(key, transactionID string) error {
 	session, col := ms.conn(colRpf)
 	defer session.Close()
-	iter := col.Find(bson.M{"id": bson.RegEx{Pattern: key + ".*", Options: ""}}).Select(bson.M{"id": 1}).Iter()
+	iter := col.Find(bson.M{"id": bson.RegEx{Pattern: strings.Replace(key,"*","\\*",-1) + ".*", Options: ""}}).Select(bson.M{"id": 1}).Iter()
 	var result struct{ Id string }
 	for iter.Next(&result) {
 		if err := col.Remove(bson.M{"id": result.Id}); err != nil {


### PR DESCRIPTION
When we make a regex to find an object in mongo, we must escape the character *