### PR TITLE
/var/log/cgrates directory is no longer created and used

### DIFF
--- a/packages/jessie/postinst
+++ b/packages/jessie/postinst
@@ -28,7 +28,6 @@ case "$1" in
 
 	configure)
 		adduser --quiet --system --group --disabled-password --shell /bin/false --gecos "CGRateS" cgrates || true
-		chown -R cgrates:cgrates /var/log/cgrates/
 		chown -R cgrates:cgrates /var/spool/cgrates/
 		chown -R cgrates:cgrates /var/lib/cgrates/
 		chown -R cgrates:cgrates /usr/share/cgrates/

--- a/packages/squeeze/postinst
+++ b/packages/squeeze/postinst
@@ -28,7 +28,6 @@ case "$1" in
 
 	configure)
 		adduser --quiet --system --group --disabled-password --shell /bin/false --gecos "CGRateS" cgrates || true
-		chown -R cgrates:cgrates /var/log/cgrates/
 		chown -R cgrates:cgrates /var/lib/cgrates/
 		chown -R cgrates:cgrates /var/spool/cgrates/
 		chown -R cgrates:cgrates /usr/share/cgrates/


### PR DESCRIPTION
Since the directory is no longer created, the postinstall script fails
and the package cannot be installed.

A temporary fix is to manually create the directory, but it is no longer
used anyway in the config file.