### PR TITLE
Add DebitUsageWithOptions endpoint

### DIFF
--- a/apier/v1/debit_test.go
+++ b/apier/v1/debit_test.go
@@ -1,0 +1,156 @@
+/*
+Real-time Online/Offline Charging System (OCS) for Telecom & ISP environments
+Copyright (C) ITsysCOM GmbH
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+package v1
+
+import (
+	"flag"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cgrates/cgrates/config"
+	"github.com/cgrates/cgrates/engine"
+	"github.com/cgrates/cgrates/utils"
+)
+
+var (
+	apierDebit        *ApierV1
+	apierDebitStorage *engine.MapStorage
+	responder         *engine.Responder
+)
+
+func TestMain(m *testing.M) {
+	apierDebitStorage, _ = engine.NewMapStorage()
+	cfg, _ := config.NewDefaultCGRConfig()
+	responder := new(engine.Responder)
+
+	engine.SetAccountingStorage(apierDebitStorage)
+	engine.SetRatingStorage(apierDebitStorage)
+	apierDebit = &ApierV1{
+		AccountDb: engine.AccountingStorage(apierDebitStorage),
+		RatingDb:  engine.RatingStorage(apierDebitStorage),
+		Config:    cfg,
+		Responder: responder,
+	}
+
+	flag.Parse()
+	os.Exit(m.Run())
+}
+
+func TestDebitUsageWithOptions(t *testing.T) {
+	cgrTenant := "cgrates.org"
+	b10 := &engine.Balance{Value: 10, Weight: 10}
+	cgrAcnt1 := &engine.Account{
+		ID: utils.ConcatenatedKey(cgrTenant, "account1"),
+		BalanceMap: map[string]engine.Balances{
+			utils.MONETARY: engine.Balances{b10},
+		},
+	}
+	if err := apierDebitStorage.SetAccount(cgrAcnt1); err != nil {
+		t.Error(err)
+	}
+
+	dstDe := &engine.Destination{Id: "*any", Prefixes: []string{"*any"}}
+	if err := apierDebitStorage.SetDestination(dstDe, utils.NonTransactional); err != nil {
+		t.Error(err)
+	}
+	if err := apierDebitStorage.SetReverseDestination(dstDe, utils.NonTransactional); err != nil {
+		t.Error(err)
+	}
+	rp1 := &engine.RatingPlan{
+		Id: "RP1",
+		Timings: map[string]*engine.RITiming{
+			"30eab300": &engine.RITiming{
+				Years:     utils.Years{},
+				Months:    utils.Months{},
+				MonthDays: utils.MonthDays{},
+				WeekDays:  utils.WeekDays{},
+				StartTime: "00:00:00",
+			},
+		},
+		Ratings: map[string]*engine.RIRate{
+			"b457f86d": &engine.RIRate{
+				ConnectFee: 0,
+				Rates: []*engine.Rate{
+					&engine.Rate{
+						GroupIntervalStart: 0,
+						Value:              0.03,
+						RateIncrement:      time.Second,
+						RateUnit:           time.Second,
+					},
+				},
+				RoundingMethod:   utils.ROUNDING_MIDDLE,
+				RoundingDecimals: 4,
+			},
+		},
+		DestinationRates: map[string]engine.RPRateList{
+			dstDe.Id: []*engine.RPRate{
+				&engine.RPRate{
+					Timing: "30eab300",
+					Rating: "b457f86d",
+					Weight: 10,
+				},
+			},
+		},
+	}
+	if err := apierDebitStorage.SetRatingPlan(rp1, utils.NonTransactional); err != nil {
+		t.Error(err)
+	}
+
+	rpfl := &engine.RatingProfile{Id: "*out:cgrates.org:call:account1",
+		RatingPlanActivations: engine.RatingPlanActivations{&engine.RatingPlanActivation{
+			ActivationTime: time.Date(2001, 1, 1, 8, 0, 0, 0, time.UTC),
+			RatingPlanId:   rp1.Id,
+			FallbackKeys:   []string{},
+		}},
+	}
+	if err := apierDebitStorage.SetRatingProfile(rpfl, utils.NonTransactional); err != nil {
+		t.Error(err)
+	}
+
+	allowNegativeOpt := AttrDebitUsageOptions{
+		AllowNegative: false,
+	}
+
+	usageRecord := engine.UsageRecord{
+		Tenant:      cgrTenant,
+		Account:     "account1",
+		Destination: "*any",
+		Usage:       "1",
+		ToR:         utils.MONETARY,
+		Category:    "call",
+		Direction:   "*out",
+		SetupTime:   time.Date(2013, 11, 7, 7, 42, 20, 0, time.UTC).String(),
+		AnswerTime:  time.Date(2013, 11, 7, 7, 42, 20, 0, time.UTC).String(),
+	}
+
+	var reply string
+	if err := apierDebit.DebitUsageWithOptions(AttrDebitUsageWithOptions{Options: allowNegativeOpt, UsageRecord: usageRecord}, &reply); err != nil {
+		t.Error(err)
+	}
+
+	// Reload the account and verify that the usage of $1 was removed from the monetary balance
+	resolvedAccount, err := apierDebitStorage.GetAccount(cgrAcnt1.ID)
+	if err != nil {
+		t.Error(err)
+	}
+	eAcntVal := 9.0
+	if resolvedAccount.BalanceMap[utils.MONETARY].GetTotalValue() != eAcntVal {
+		t.Errorf("Expected: %f, received: %f", eAcntVal, resolvedAccount.BalanceMap[utils.MONETARY].GetTotalValue())
+	}
+}

--- a/engine/calldesc.go
+++ b/engine/calldesc.go
@@ -158,6 +158,7 @@ type CallDescriptor struct {
 	ForceDuration   bool // for Max debit if less than duration return err
 	PerformRounding bool // flag for rating info rounding
 	DryRun          bool
+	AllowNegative   bool
 	account         *Account
 	testCallcost    *CallCost // testing purpose only!
 }
@@ -699,7 +700,7 @@ func (cd *CallDescriptor) Debit() (cc *CallCost, err error) {
 	} else {
 		if memberIds, sgerr := account.GetUniqueSharedGroupMembers(cd); sgerr == nil {
 			_, err = Guardian.Guard(func() (interface{}, error) {
-				cc, err = cd.debit(account, cd.DryRun, true)
+				cc, err = cd.debit(account, cd.DryRun, cd.AllowNegative)
 				return 0, err
 			}, 0, memberIds.Slice()...)
 		} else {

--- a/engine/calldesc_test.go
+++ b/engine/calldesc_test.go
@@ -284,7 +284,7 @@ func TestGetCostRounding(t *testing.T) {
 func TestDebitRounding(t *testing.T) {
 	t1 := time.Date(2017, time.February, 2, 17, 30, 0, 0, time.UTC)
 	t2 := time.Date(2017, time.February, 2, 17, 33, 0, 0, time.UTC)
-	cd := &CallDescriptor{Direction: "*out", Category: "call", Tenant: "cgrates.org", Subject: "round", Destination: "49", TimeStart: t1, TimeEnd: t2, LoopIndex: 0}
+	cd := &CallDescriptor{Direction: "*out", Category: "call", Tenant: "cgrates.org", Subject: "round", Destination: "49", TimeStart: t1, TimeEnd: t2, LoopIndex: 0, AllowNegative: true}
 	result, _ := cd.Debit()
 	if result.Cost != 0.30006 || result.GetConnectFee() != 0 { // should be 0.3 :(
 		t.Error("bad cost", utils.ToIJSON(result))
@@ -294,7 +294,7 @@ func TestDebitRounding(t *testing.T) {
 func TestDebitPerformRounding(t *testing.T) {
 	t1 := time.Date(2017, time.February, 2, 17, 30, 0, 0, time.UTC)
 	t2 := time.Date(2017, time.February, 2, 17, 33, 0, 0, time.UTC)
-	cd := &CallDescriptor{Direction: "*out", Category: "call", Tenant: "cgrates.org", Subject: "round", Destination: "49", TimeStart: t1, TimeEnd: t2, LoopIndex: 0, PerformRounding: true}
+	cd := &CallDescriptor{Direction: "*out", Category: "call", Tenant: "cgrates.org", Subject: "round", Destination: "49", TimeStart: t1, TimeEnd: t2, LoopIndex: 0, PerformRounding: true, AllowNegative: true}
 	result, _ := cd.Debit()
 	if result.Cost != 0.3001 || result.GetConnectFee() != 0 { // should be 0.3 :(
 		t.Error("bad cost", utils.ToIJSON(result))
@@ -793,15 +793,16 @@ func TestDebitRatingInfoOnZeroTime(t *testing.T) {
 		at.Execute()
 	}
 	cd := &CallDescriptor{
-		Direction:    "*out",
-		Category:     "call",
-		Tenant:       "cgrates.org",
-		Subject:      "dy",
-		Account:      "dy",
-		Destination:  "0723123113",
-		TimeStart:    time.Date(2015, 10, 26, 13, 29, 27, 0, time.UTC),
-		TimeEnd:      time.Date(2015, 10, 26, 13, 29, 27, 0, time.UTC),
-		MaxCostSoFar: 0,
+		Direction:     "*out",
+		Category:      "call",
+		Tenant:        "cgrates.org",
+		Subject:       "dy",
+		Account:       "dy",
+		Destination:   "0723123113",
+		TimeStart:     time.Date(2015, 10, 26, 13, 29, 27, 0, time.UTC),
+		TimeEnd:       time.Date(2015, 10, 26, 13, 29, 27, 0, time.UTC),
+		MaxCostSoFar:  0,
+		AllowNegative: true,
 	}
 	cc, err := cd.Debit()
 	if err != nil ||
@@ -918,6 +919,7 @@ func TestDebitRoundingRefund(t *testing.T) {
 		TimeEnd:         time.Date(2016, 3, 4, 13, 53, 00, 0, time.UTC),
 		MaxCostSoFar:    0,
 		PerformRounding: true,
+		AllowNegative:   true,
 	}
 	acc, err := accountingStorage.GetAccount("cgrates.org:dy")
 	if err != nil || acc.BalanceMap[utils.MONETARY][0].Value != 1 {
@@ -1202,14 +1204,15 @@ func TestMaxDebitDurationNoGreatherThanInitialDuration(t *testing.T) {
 
 func TestDebitAndMaxDebit(t *testing.T) {
 	cd1 := &CallDescriptor{
-		TimeStart:   time.Date(2013, 10, 21, 18, 34, 0, 0, time.UTC),
-		TimeEnd:     time.Date(2013, 10, 21, 18, 34, 10, 0, time.UTC),
-		Direction:   "*out",
-		Category:    "0",
-		Tenant:      "vdf",
-		Subject:     "minu_from_tm",
-		Account:     "minu",
-		Destination: "0723",
+		TimeStart:     time.Date(2013, 10, 21, 18, 34, 0, 0, time.UTC),
+		TimeEnd:       time.Date(2013, 10, 21, 18, 34, 10, 0, time.UTC),
+		Direction:     "*out",
+		Category:      "0",
+		Tenant:        "vdf",
+		Subject:       "minu_from_tm",
+		Account:       "minu",
+		Destination:   "0723",
+		AllowNegative: true,
 	}
 	cd2 := cd1.Clone()
 	cc1, err1 := cd1.Debit()

--- a/engine/cdr.go
+++ b/engine/cdr.go
@@ -888,14 +888,15 @@ func (self *UsageRecord) AsStoredCdr(timezone string) (*CDR, error) {
 func (self *UsageRecord) AsCallDescriptor(timezone string) (*CallDescriptor, error) {
 	var err error
 	cd := &CallDescriptor{
-		CgrID:       self.GetId(),
-		TOR:         self.ToR,
-		Direction:   self.Direction,
-		Tenant:      self.Tenant,
-		Category:    self.Category,
-		Subject:     self.Subject,
-		Account:     self.Account,
-		Destination: self.Destination,
+		CgrID:         self.GetId(),
+		TOR:           self.ToR,
+		Direction:     self.Direction,
+		Tenant:        self.Tenant,
+		Category:      self.Category,
+		Subject:       self.Subject,
+		Account:       self.Account,
+		Destination:   self.Destination,
+		AllowNegative: true,
 	}
 	timeStr := self.AnswerTime
 	if len(timeStr) == 0 { // In case of auth, answer time will not be defined, so take it out of setup one

--- a/engine/cdr_test.go
+++ b/engine/cdr_test.go
@@ -473,7 +473,7 @@ func TestUsageReqAsCD(t *testing.T) {
 		Account: "1001", Subject: "1001", Destination: "1002",
 		SetupTime: "2013-11-07T08:42:20Z", AnswerTime: "2013-11-07T08:42:26Z", Usage: "0.00000001",
 	}
-	eCD := &CallDescriptor{CgrID: "9473e7b2e075d168b9da10ae957ee68fe5a217e4", TOR: req.ToR, Direction: req.Direction, Tenant: req.Tenant, Category: req.Category, Account: req.Account, Subject: req.Subject, Destination: req.Destination, TimeStart: time.Date(2013, 11, 7, 8, 42, 26, 0, time.UTC), TimeEnd: time.Date(2013, 11, 7, 8, 42, 26, 0, time.UTC).Add(time.Duration(10))}
+	eCD := &CallDescriptor{CgrID: "9473e7b2e075d168b9da10ae957ee68fe5a217e4", TOR: req.ToR, Direction: req.Direction, Tenant: req.Tenant, Category: req.Category, Account: req.Account, Subject: req.Subject, Destination: req.Destination, TimeStart: time.Date(2013, 11, 7, 8, 42, 26, 0, time.UTC), TimeEnd: time.Date(2013, 11, 7, 8, 42, 26, 0, time.UTC).Add(time.Duration(10)), AllowNegative: true}
 	if cd, err := req.AsCallDescriptor(""); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(eCD, cd) {

--- a/general_tests/ddazmbl1_test.go
+++ b/general_tests/ddazmbl1_test.go
@@ -144,14 +144,15 @@ func TestExecuteActions(t *testing.T) {
 
 func TestDebit(t *testing.T) {
 	cd := &engine.CallDescriptor{
-		Direction:   "*out",
-		Category:    "call",
-		Tenant:      "cgrates.org",
-		Subject:     "12344",
-		Account:     "12344",
-		Destination: "447956933443",
-		TimeStart:   time.Date(2014, 3, 4, 6, 0, 0, 0, time.UTC),
-		TimeEnd:     time.Date(2014, 3, 4, 6, 0, 10, 0, time.UTC),
+		Direction:     "*out",
+		Category:      "call",
+		Tenant:        "cgrates.org",
+		Subject:       "12344",
+		Account:       "12344",
+		Destination:   "447956933443",
+		TimeStart:     time.Date(2014, 3, 4, 6, 0, 0, 0, time.UTC),
+		TimeEnd:       time.Date(2014, 3, 4, 6, 0, 10, 0, time.UTC),
+		AllowNegative: true,
 	}
 	if cc, err := cd.Debit(); err != nil {
 		t.Error(err)

--- a/general_tests/ddazmbl2_test.go
+++ b/general_tests/ddazmbl2_test.go
@@ -144,14 +144,15 @@ func TestExecuteActions2(t *testing.T) {
 
 func TestDebit2(t *testing.T) {
 	cd := &engine.CallDescriptor{
-		Direction:   "*out",
-		Category:    "call",
-		Tenant:      "cgrates.org",
-		Subject:     "12345",
-		Account:     "12345",
-		Destination: "447956933443",
-		TimeStart:   time.Date(2014, 3, 4, 6, 0, 0, 0, time.UTC),
-		TimeEnd:     time.Date(2014, 3, 4, 6, 0, 10, 0, time.UTC),
+		Direction:     "*out",
+		Category:      "call",
+		Tenant:        "cgrates.org",
+		Subject:       "12345",
+		Account:       "12345",
+		Destination:   "447956933443",
+		TimeStart:     time.Date(2014, 3, 4, 6, 0, 0, 0, time.UTC),
+		TimeEnd:       time.Date(2014, 3, 4, 6, 0, 10, 0, time.UTC),
+		AllowNegative: true,
 	}
 	if cc, err := cd.Debit(); err != nil {
 		t.Error(err)

--- a/general_tests/ddazmbl3_test.go
+++ b/general_tests/ddazmbl3_test.go
@@ -140,14 +140,15 @@ func TestExecuteActions3(t *testing.T) {
 
 func TestDebit3(t *testing.T) {
 	cd := &engine.CallDescriptor{
-		Direction:   "*out",
-		Category:    "call",
-		Tenant:      "cgrates.org",
-		Subject:     "12346",
-		Account:     "12346",
-		Destination: "447956933443",
-		TimeStart:   time.Date(2014, 3, 4, 6, 0, 0, 0, time.UTC),
-		TimeEnd:     time.Date(2014, 3, 4, 6, 0, 10, 0, time.UTC),
+		Direction:     "*out",
+		Category:      "call",
+		Tenant:        "cgrates.org",
+		Subject:       "12346",
+		Account:       "12346",
+		Destination:   "447956933443",
+		TimeStart:     time.Date(2014, 3, 4, 6, 0, 0, 0, time.UTC),
+		TimeEnd:       time.Date(2014, 3, 4, 6, 0, 10, 0, time.UTC),
+		AllowNegative: true,
 	}
 	if cc, err := cd.Debit(); err != nil {
 		t.Error(err)


### PR DESCRIPTION
This endpoint allows the caller to determine if the account should be allowed to go negative.

I was originally envisioning the endpoint to reject the request if it resulted in a negative balance, but I couldn't see a clean way to do that with the existing code. I could see adding another option in the future to the options struct to allow the caller to decide if CGRates should reject the call if it results in a negative balance.