### PR TITLE
Update tut_kamailio_installs.rst

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -53,6 +53,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @Edwardro22 | Eduard Tamşa |
 | @KuikenArjan | Arjan Kuiken |
 | @Dobby16 | Arjan Kuiken |
+| @pauls1024 | Paul Smith |
 
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |

--- a/docs/tut_kamailio_installs.rst
+++ b/docs/tut_kamailio_installs.rst
@@ -10,7 +10,7 @@ We got Kamailio_ installed via following commands:
 ::
 
  apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xfb40d3e6508ea4c8
- echo "deb http://deb.kamailio.org/kamailio43 jessie main" > /etc/apt/sources.list.d/kamailio.list
+ echo "deb http://deb.kamailio.org/kamailio44 jessie main" > /etc/apt/sources.list.d/kamailio.list
  apt-get update
  apt-get install kamailio kamailio-extra-modules kamailio-json-modules
 


### PR DESCRIPTION
There is a bug "Evapi module is not broadcasting any data" in evapi in kamailio43 which was fixed in kamailio44. ref:http://lists.sip-router.org/pipermail/sr-users/2016-August/094249.html
ref: Daniel on Kamailio users list : "It should be fixed now in the latest 4.4 and master branches. Cheers,Daniel"