### PR TITLE
This PR closes issue #672 - sm_freeswitch is not sending calls to empty_balance_context anymore 

### DIFF
--- a/sessionmanager/fssessionmanager.go
+++ b/sessionmanager/fssessionmanager.go
@@ -95,6 +95,12 @@ func (sm *FSSessionManager) setMaxCallDuration(uuid, connId string, maxDur time.
             return err
         }
         return nil
+    }  else if len(sm.cfg.EmptyBalanceAnnFile) != 0 {
+            if _, err := sm.conns[connId].SendApiCmd(fmt.Sprintf("sched_api +%d uuid_broadcast %s playback!manager_request::%s aleg\n\n", int(maxDur.Seconds()), uuid, sm.cfg.EmptyBalanceAnnFile)); err != nil {
+            utils.Logger.Err(fmt.Sprintf("<SM-FreeSWITCH> Could not send uuid_broadcast to freeswitch, error: <%s>, connId: %s", err.Error(), connId))
+            return err
+        }
+        return nil
     } else {
         _, err := sm.conns[connId].SendApiCmd(fmt.Sprintf("uuid_setvar %s execute_on_answer sched_hangup +%d alloted_timeout\n\n", uuid, int(maxDur.Seconds())))
         if err != nil {

--- a/sessionmanager/fssessionmanager.go
+++ b/sessionmanager/fssessionmanager.go
@@ -96,7 +96,7 @@ func (sm *FSSessionManager) setMaxCallDuration(uuid, connId string, maxDur time.
         }
         return nil
     }  else if len(sm.cfg.EmptyBalanceAnnFile) != 0 {
-            if _, err := sm.conns[connId].SendApiCmd(fmt.Sprintf("sched_api +%d uuid_broadcast %s playback!manager_request::%s aleg\n\n", int(maxDur.Seconds()), uuid, sm.cfg.EmptyBalanceAnnFile)); err != nil {
+            if _, err := sm.conns[connId].SendApiCmd(fmt.Sprintf("sched_broadcast +%d %s playback!manager_request::%s aleg\n\n", int(maxDur.Seconds()), uuid, sm.cfg.EmptyBalanceAnnFile)); err != nil {
             utils.Logger.Err(fmt.Sprintf("<SM-FreeSWITCH> Could not send uuid_broadcast to freeswitch, error: <%s>, connId: %s", err.Error(), connId))
             return err
         }

--- a/sessionmanager/fssessionmanager.go
+++ b/sessionmanager/fssessionmanager.go
@@ -86,12 +86,22 @@ func (sm *FSSessionManager) createHandlers() map[string][]func(string, string) {
 }
 
 // Sets the call timeout valid of starting of the call
-func (sm *FSSessionManager) setMaxCallDuration(uuid, connId string, maxDur time.Duration) error {
+func (sm *FSSessionManager) setMaxCallDuration(uuid, connId string, maxDur time.Duration, DestNr string) error {
 	// _, err := fsock.FS.SendApiCmd(fmt.Sprintf("sched_hangup +%d %s\n\n", int(maxDur.Seconds()), uuid))
-	_, err := sm.conns[connId].SendApiCmd(fmt.Sprintf("uuid_setvar %s execute_on_answer sched_hangup +%d alloted_timeout\n\n", uuid, int(maxDur.Seconds())))
-	if err != nil {
-		utils.Logger.Err(fmt.Sprintf("<SM-FreeSWITCH> Could not send sched_hangup command to freeswitch, error: <%s>, connId: %s", err.Error(), connId))
-		return err
+    if len(sm.cfg.EmptyBalanceContext) != 0 {
+        _, err := sm.conns[connId].SendApiCmd(fmt.Sprintf("uuid_setvar %s execute_on_answer sched_transfer +%d %s XML %s\n\n", uuid, int(maxDur.Seconds()), DestNr, sm.cfg.EmptyBalanceContext))
+        if err != nil {
+            utils.Logger.Err(fmt.Sprintf("<SM-FreeSWITCH> Could not transfer the call to empty balance context, error: <%s>, connId: %s", err.Error(), connId))
+            return err
+        }
+        return nil
+    } else {
+        _, err := sm.conns[connId].SendApiCmd(fmt.Sprintf("uuid_setvar %s execute_on_answer sched_hangup +%d alloted_timeout\n\n", uuid, int(maxDur.Seconds())))
+        if err != nil {
+            utils.Logger.Err(fmt.Sprintf("<SM-FreeSWITCH> Could not send sched_hangup command to freeswitch, error: <%s>, connId: %s", err.Error(), connId))
+            return err
+        }
+	    return nil
 	}
 	return nil
 }
@@ -149,7 +159,7 @@ func (sm *FSSessionManager) onChannelPark(ev engine.Event, connId string) {
 				sm.unparkCall(ev.GetUUID(), connId, ev.GetCallDestNr(utils.META_DEFAULT), INSUFFICIENT_FUNDS)
 				return
 			}
-			sm.setMaxCallDuration(ev.GetUUID(), connId, maxCallDur)
+			sm.setMaxCallDuration(ev.GetUUID(), connId, maxCallDur, ev.GetCallDestNr(utils.META_DEFAULT))
 		}
 	}
 	// ComputeLcr


### PR DESCRIPTION
If there is an empty_balance_context configured sm_freeswitch should send this call to this context not disconnect active call via sched_hangup.