### PR TITLE
Include git commit ref and date in package version

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -63,6 +63,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @basitengr | Abdul Basit |
 | @ghenry | Gavin Henry |
 | @Anevo | Cezar Vulcu |
+| @deanone-noc | dean one noc |
 
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,12 +1,46 @@
+DISTRIBUTION ?= jessie
+
+GIT_COMMIT=$(shell git log -n1 --format=format:%h)
+GIT_DATE=$(shell date +%Y%m%d --date="@$(shell git log -n1 --format=format:%ct)")
+
+ifeq ($(GIT_COMMIT),)
+	echo "Error: Failed to extract commit from git log"
+	exit 1
+endif
+ifeq ($(GIT_DATE),)
+	echo "Error: Failed to extract date from git log"
+	exit 1
+endif
+
+JESSIE_VERSION=$(shell dpkg-parsechangelog -S Version -l jessie/changelog 2> /dev/null)
+
+ifeq ($(JESSIE_VERSION),)
+	echo "Error: Failed to extract version from jessie changelog"
+	exit 1
+endif
+
+JESSIE_PKG_VERSION=$(JESSIE_VERSION)+$(GIT_DATE)+$(GIT_COMMIT)
+
+SQUEEZE_VERSION=$(shell dpkg-parsechangelog -S Version -l squeeze/changelog 2> /dev/null)
+
+ifeq ($(SQUEEZE_VERSION),)
+	echo "Error: Failed to extract version from squeeze changelog"
+	exit 1
+endif
+
+SQUEEZE_PKG_VERSION=$(SQUEEZE_VERSION)+$(GIT_DATE)+$(GIT_COMMIT)
+
 make deb:
 	cd ..;\
 	ln -sf packages/jessie debian ;\
+	dch -v "$(JESSIE_PKG_VERSION)" -m "Package build for git commit $(GIT_COMMIT) ($(GIT_DATE))." -D "$(DISTRIBUTION)" ;\
 	dpkg-buildpackage -rfakeroot -tc; \
 	rm debian
 
 make squeeze:
 	cd ..;\
 	ln -sf packages/squeeze debian ;\
+	dch -v "$(SQUEEZE_PKG_VERSION)" -m "Package build for git commit $(GIT_COMMIT) ($(GIT_DATE))." -D "$(DISTRIBUTION)" ;\
 	dpkg-buildpackage -rfakeroot -tc; \
 	rm debian
 

--- a/packages/jessie/changelog
+++ b/packages/jessie/changelog
@@ -2,32 +2,32 @@ cgrates (0.9.1~rc8) UNRELEASED; urgency=low
 
   * RC8.
 
- -- DanB <danb@cgrates.org>  Monday, 22 September 2015 12:05:00 +0200
+ -- DanB <danb@cgrates.org>  Mon, 22 Sep 2015 12:05:00 +0200
 
 cgrates (0.9.1~rc7) UNRELEASED; urgency=low
 
   * RC7.
 
- -- DanB <danb@cgrates.org>  Wednesday, 3 August 2015 14:04:00 -0600
+ -- DanB <danb@cgrates.org>  Wed, 3 Aug 2015 14:04:00 -0600
 
 cgrates (0.9.1~rc6) UNRELEASED; urgency=low
 
   * RC6.
 
- -- DanB <danb@cgrates.org>  Wednesday, 10 September 2014 13:30:00 +0100
+ -- DanB <danb@cgrates.org>  Wed, 10 Sep 2014 13:30:00 +0100
 
 cgrates (0.9.1~rc5) UNRELEASED; urgency=low
 
   * RC5.
 
- -- DanB <danb@cgrates.org>  Monday, 18 August 2014 13:30:00 +0100
+ -- DanB <danb@cgrates.org>  Mon, 18 Aug 2014 13:30:00 +0100
 
 
 cgrates (0.9.1~rc4) UNRELEASED; urgency=low
 
   * RC4.
 
- -- DanB <danb@cgrates.org>  Thursday, 25 March 2014 17:30:00 +0100
+ -- DanB <danb@cgrates.org>  Thu, 25 Mar 2014 17:30:00 +0100
 
 cgrates (0.9.1~rc3) UNRELEASED; urgency=low
 

--- a/packages/squeeze/changelog
+++ b/packages/squeeze/changelog
@@ -2,32 +2,32 @@ cgrates (0.9.1~rc8) UNRELEASED; urgency=low
 
   * RC8.
 
- -- DanB <danb@cgrates.org>  Monday, 22 September 2015 12:05:00 +0200
+ -- DanB <danb@cgrates.org>  Mon, 22 Sep 2015 12:05:00 +0200
 
 cgrates (0.9.1~rc7) UNRELEASED; urgency=low
 
   * RC7.
 
- -- DanB <danb@cgrates.org>  Wednesday, 3 August 2015 14:04:00 -0600
+ -- DanB <danb@cgrates.org>  Wed, 3 Aug 2015 14:04:00 -0600
 
 cgrates (0.9.1~rc6) UNRELEASED; urgency=low
 
   * RC6.
 
- -- DanB <danb@cgrates.org>  Wednesday, 10 September 2014 13:30:00 +0100
+ -- DanB <danb@cgrates.org>  Wed, 10 Sep 2014 13:30:00 +0100
 
 cgrates (0.9.1~rc5) UNRELEASED; urgency=low
 
   * RC5.
 
- -- DanB <danb@cgrates.org>  Monday, 18 August 2014 13:30:00 +0100
+ -- DanB <danb@cgrates.org>  Mon, 18 Aug 2014 13:30:00 +0100
 
 
 cgrates (0.9.1~rc4) UNRELEASED; urgency=low
 
   * RC4.
 
- -- DanB <danb@cgrates.org>  Thursday, 25 March 2014 17:30:00 +0100
+ -- DanB <danb@cgrates.org>  Thu, 25 Mar 2014 17:30:00 +0100
 
 cgrates (0.9.1~rc3) UNRELEASED; urgency=low
 


### PR DESCRIPTION
This allows adding custom built cgrates packages to be upgraded with apt.

Also fix the date syntax in the Debian package changelog files.