### PR TITLE
Fix Overwrite for ratingprofile_set console command

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -64,6 +64,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @ghenry | Gavin Henry |
 | @Anevo | Cezar Vulcu |
 | @deanone-noc | dean one noc |
+| @cruzccl | Carlos Cruz Luengo |
 
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |

--- a/console/ratingprofile_set.go
+++ b/console/ratingprofile_set.go
@@ -18,7 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 package console
 
-import "github.com/cgrates/cgrates/utils"
+import "github.com/cgrates/cgrates/apier/v1"
 
 func init() {
 	c := &CmdSetRatingProfile{
@@ -33,7 +33,7 @@ func init() {
 type CmdSetRatingProfile struct {
 	name      string
 	rpcMethod string
-	rpcParams *utils.TPRatingProfile
+	rpcParams *v1.AttrSetRatingProfile
 	rpcResult string
 	*CommandExecuter
 }
@@ -48,7 +48,7 @@ func (self *CmdSetRatingProfile) RpcMethod() string {
 
 func (self *CmdSetRatingProfile) RpcParams(reset bool) interface{} {
 	if reset || self.rpcParams == nil {
-		self.rpcParams = &utils.TPRatingProfile{}
+		self.rpcParams = &v1.AttrSetRatingProfile{}
 	}
 	return self.rpcParams
 }


### PR DESCRIPTION
This commit fixes rpcParams type so that Overwrite attribute gets
usable through ratingprofile_set command.