### PR TITLE
Update cgrates.service

### DIFF
--- a/packages/redhat_fedora/cgrates.service
+++ b/packages/redhat_fedora/cgrates.service
@@ -10,6 +10,7 @@ EnvironmentFile=-/etc/sysconfig/cgrates
 ExecStart=/usr/bin/cgr-engine $OPTIONS
 Restart=always
 TimeoutStopSec=30s
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add RestartSec parameter to get rid of entering in failed state when service restarts too quickly:
systemd[1]: cgrates.service holdoff time over, scheduling restart.
systemd[1]: start request repeated too quickly for cgrates.service
systemd[1]: Failed to start Carrier Grade Real-time Charging System.
systemd[1]: Unit cgrates.service entered failed state.
systemd[1]: cgrates.service failed.