### PR TITLE
Fixes #1197 Protecting concurrent access to cdre

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -68,6 +68,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @petekelly | Peter Kelly |
 | @vtzan | Vasilios Tzanoudakis |
 | @ccppprogrammer | Sergei Lavrov |
+| @chrisgis333 | Krzysztof Grzyb |
 
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |

--- a/engine/cdre.go
+++ b/engine/cdre.go
@@ -331,6 +331,8 @@ func (cdre *CDRExporter) processCDR(cdr *CDR) (err error) {
 		return
 	}
 	// Done with writing content, compute stats here
+	cdre.Lock()
+	defer cdre.Unlock()
 	if cdre.firstCdrATime.IsZero() || cdr.AnswerTime.Before(cdre.firstCdrATime) {
 		cdre.firstCdrATime = cdr.AnswerTime
 	}


### PR DESCRIPTION
Fix for issue #1197 
When exporting cdr's, cdre was not protected from concurrent access. 
Some stats might be wrong.