### PR TITLE
Capitalize RATED constant

### DIFF
--- a/utils/consts.go
+++ b/utils/consts.go
@@ -161,7 +161,7 @@ const (
 	RunID                         = "RunID"
 	COST                          = "Cost"
 	CostDetails                   = "CostDetails"
-	RATED                         = "rated"
+	RATED                         = "Rated"
 	Partial                       = "Partial"
 	PreRated                      = "PreRated"
 	DEFAULT_RUNID                 = "*default"


### PR DESCRIPTION
Capitalize the utils.RATED constant to be in line with the docs for CDR Server https://github.com/cgrates/cgrates/blob/master/docs/cdrserver.rst