### PR TITLE
fixing rsyslog initial install permissions

### DIFF
--- a/packages/jessie/postinst
+++ b/packages/jessie/postinst
@@ -31,6 +31,7 @@ case "$1" in
 		chown -R cgrates:cgrates /var/spool/cgrates/
 		chown -R cgrates:cgrates /var/lib/cgrates/
 		chown -R cgrates:cgrates /usr/share/cgrates/
+		chown syslog:adm /var/log/cgrates
         ;;
 
 	abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/squeeze/postinst
+++ b/packages/squeeze/postinst
@@ -31,6 +31,7 @@ case "$1" in
 		chown -R cgrates:cgrates /var/lib/cgrates/
 		chown -R cgrates:cgrates /var/spool/cgrates/
 		chown -R cgrates:cgrates /usr/share/cgrates/
+		chown syslog:adm /var/log/cgrates
         ;;
 
 	abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
Found an issue on clean installs where rsyslog can't write to the folder and thus does not log

simple CHOWN during the postinst should sort, 