### PR TITLE
default logging folder permissions don't allow writes

### DIFF
--- a/packages/jessie/postinst
+++ b/packages/jessie/postinst
@@ -32,6 +32,7 @@ case "$1" in
 		chown -R cgrates:cgrates /var/lib/cgrates/
 		chown -R cgrates:cgrates /usr/share/cgrates/
 		chown root:adm /var/log/cgrates
+		chmod 775 /var/log/cgrates
         ;;
 
 	abort-upgrade|abort-remove|abort-deconfigure)

--- a/packages/squeeze/postinst
+++ b/packages/squeeze/postinst
@@ -32,6 +32,7 @@ case "$1" in
 		chown -R cgrates:cgrates /var/spool/cgrates/
 		chown -R cgrates:cgrates /usr/share/cgrates/
 		chown root:adm /var/log/cgrates
+		chmod 775 /var/log/cgrates
         ;;
 
 	abort-upgrade|abort-remove|abort-deconfigure)


### PR DESCRIPTION
So default folder permissions (755) won't allow syslog to write to the folder if owned by root, best solution is to allow group write permissions for the adm group

this allows the ownership to remain as root:adm which are default (in debian and ubuntu) users and groups always available out of the box and for rsyslog to write to the folder accordingly