### PR TITLE
fixing doc refs for cgr-migrate from migrate to exec flag

### DIFF
--- a/data/docker/prod/start.sh
+++ b/data/docker/prod/start.sh
@@ -12,7 +12,7 @@ sed -i 's/config_dir/config_path/g' /usr/share/cgrates/tutorials/fs_evsock/cgrat
 sed -i 's/\/etc\/cgrates/\/etc\/cgrates -httprof_path=\/pprof -logger=*stdout/g' /usr/share/cgrates/tutorials/fs_evsock/cgrates/etc/init.d/cgrates
 
 # Get our data ready
-/usr/bin/cgr-migrator -migrate=*set_versions -config_path=/usr/share/cgrates/tutorials/fs_evsock/cgrates/etc/cgrates/
+/usr/bin/cgr-migrator -exec=*set_versions -config_path=/usr/share/cgrates/tutorials/fs_evsock/cgrates/etc/cgrates/
 
 # Let FreeSWITCH start up
 sleep 5

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -158,7 +158,7 @@ Once database setup is completed, we need to write the versions data. To do this
 Sample usage for MySQL: 
 ::
 
-   cgr-migrator -stordb_passwd="CGRateS.org" -migrate="*set_versions"
+   cgr-migrator -stordb_passwd="CGRateS.org" -exec="*set_versions"
 
 
 3.3.3.Git

--- a/docs/tut_cgrates_installs.rst
+++ b/docs/tut_cgrates_installs.rst
@@ -43,7 +43,7 @@ As described in post-install section, we will need to set up the MySQL_ database
 Once the database is in place, we can now set versions:
 ::
 
-   cgr-migrator -stordb_passwd="CGRateS.org" -migrate="*set_versions"
+   cgr-migrator -stordb_passwd="CGRateS.org" -exec="*set_versions"
 
 At this point we have **CGRateS** installed but not yet configured. To facilitate understanding and speed up the process, **CGRateS** has the configurations used in these tutorials available in the */usr/share/cgrates/tutorials* folder.
 

--- a/engine/version.go
+++ b/engine/version.go
@@ -26,17 +26,17 @@ import (
 
 var (
 	dataDBVers = map[string]string{
-		utils.Accounts:       "cgr-migrator -migrate=*accounts",
-		utils.Attributes:     "cgr-migrator -migrate=*attributes",
-		utils.Actions:        "cgr-migrator -migrate=*actions",
-		utils.ActionTriggers: "cgr-migrator -migrate=*action_triggers",
-		utils.ActionPlans:    "cgr-migrator -migrate=*action_plans",
-		utils.SharedGroups:   "cgr-migrator -migrate=*shared_groups",
-		utils.Thresholds:     "cgr-migrator -migrate=*thresholds",
+		utils.Accounts:       "cgr-migrator -exec=*accounts",
+		utils.Attributes:     "cgr-migrator -exec=*attributes",
+		utils.Actions:        "cgr-migrator -exec=*actions",
+		utils.ActionTriggers: "cgr-migrator -exec=*action_triggers",
+		utils.ActionPlans:    "cgr-migrator -exec=*action_plans",
+		utils.SharedGroups:   "cgr-migrator -exec=*shared_groups",
+		utils.Thresholds:     "cgr-migrator -exec=*thresholds",
 	}
 	storDBVers = map[string]string{
-		utils.CostDetails:   "cgr-migrator -migrate=*cost_details",
-		utils.SessionSCosts: "cgr-migrator -migrate=*sessions_costs",
+		utils.CostDetails:   "cgr-migrator -exec=*cost_details",
+		utils.SessionSCosts: "cgr-migrator -exec=*sessions_costs",
 	}
 	allVers map[string]string // init will fill this with a merge of data+stor
 )
@@ -67,7 +67,7 @@ func CheckVersions(storage Storage) error {
 			return err
 		}
 		if !empty {
-			return fmt.Errorf("No versions defined: please backup cgrates data and run : <cgr-migrator -migrate=*set_versions>")
+			return fmt.Errorf("No versions defined: please backup cgrates data and run : <cgr-migrator -exec=*set_versions>")
 		}
 		// no data, safe to write version
 		if err := OverwriteDBVersions(storage); err != nil {

--- a/engine/version_test.go
+++ b/engine/version_test.go
@@ -46,28 +46,28 @@ func TestVersionCompare(t *testing.T) {
 		utils.SharedGroups: 2, utils.CostDetails: 2,
 		utils.SessionSCosts: 2}
 	message1 := y.Compare(x, utils.MONGO, true)
-	if message1 != "cgr-migrator -migrate=*accounts" {
-		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -migrate=*accounts", message1)
+	if message1 != "cgr-migrator -exec=*accounts" {
+		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -exec=*accounts", message1)
 	}
 	message2 := z.Compare(x, utils.MONGO, true)
-	if message2 != "cgr-migrator -migrate=*action_plans" {
-		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -migrate=*action_plans", message2)
+	if message2 != "cgr-migrator -exec=*action_plans" {
+		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -exec=*action_plans", message2)
 	}
 	message3 := q.Compare(x, utils.MONGO, true)
-	if message3 != "cgr-migrator -migrate=*shared_groups" {
-		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -migrate=*shared_groups", message3)
+	if message3 != "cgr-migrator -exec=*shared_groups" {
+		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -exec=*shared_groups", message3)
 	}
 	message4 := c.Compare(x, utils.MONGO, false)
-	if message4 != "cgr-migrator -migrate=*cost_details" {
-		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -migrate=*cost_details", message4)
+	if message4 != "cgr-migrator -exec=*cost_details" {
+		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -exec=*cost_details", message4)
 	}
 	message5 := a.Compare(b, utils.MYSQL, false)
-	if message5 != "cgr-migrator -migrate=*sessions_costs" {
-		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -migrate=*sessions_costs", message5)
+	if message5 != "cgr-migrator -exec=*sessions_costs" {
+		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -exec=*sessions_costs", message5)
 	}
 	message6 := a.Compare(b, utils.POSTGRES, false)
-	if message6 != "cgr-migrator -migrate=*sessions_costs" {
-		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -migrate=*sessions_costs", message6)
+	if message6 != "cgr-migrator -exec=*sessions_costs" {
+		t.Errorf("Error failed to compare to curent version expected: %s received: %s", "cgr-migrator -exec=*sessions_costs", message6)
 	}
 
 }

--- a/engine/versions_it_test.go
+++ b/engine/versions_it_test.go
@@ -161,13 +161,13 @@ func testVersion(t *testing.T) {
 		currentVersion = allVersions
 		testVersion = allVersions
 		testVersion[utils.Accounts] = 1
-		test = "Migration needed: please backup cgr data and run : <cgr-migrator -migrate=*accounts>"
+		test = "Migration needed: please backup cgr data and run : <cgr-migrator -exec=*accounts>"
 	case utils.MONGO, utils.REDIS:
 		currentVersion = dataDbVersions
 		testVersion = dataDbVersions
 		testVersion[utils.Accounts] = 1
 
-		test = "Migration needed: please backup cgr data and run : <cgr-migrator -migrate=*accounts>"
+		test = "Migration needed: please backup cgr data and run : <cgr-migrator -exec=*accounts>"
 	}
 
 	//dataDB
@@ -203,12 +203,12 @@ func testVersion(t *testing.T) {
 		currentVersion = allVersions
 		testVersion = allVersions
 		testVersion[utils.Accounts] = 1
-		test = "Migration needed: please backup cgr data and run : <cgr-migrator -migrate=*accounts>"
+		test = "Migration needed: please backup cgr data and run : <cgr-migrator -exec=*accounts>"
 	case utils.MONGO, utils.POSTGRES, utils.MYSQL:
 		currentVersion = storDbVersions
 		testVersion = allVersions
 		testVersion[utils.CostDetails] = 1
-		test = "Migration needed: please backup cgr data and run : <cgr-migrator -migrate=*cost_details>"
+		test = "Migration needed: please backup cgr data and run : <cgr-migrator -exec=*cost_details>"
 	}
 	//storageDb
 


### PR DESCRIPTION
this is a documentation/feedback change to update the fact that cgr-migrator uses the -exec flag rather than the -migrate flag now