### PR TITLE
Use DAEMON_OPTS from default file in systemd service too.

### DIFF
--- a/packages/jessie/cgrates.service
+++ b/packages/jessie/cgrates.service
@@ -16,7 +16,8 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/cgr-engine
+EnvironmentFile=-/etc/default/cgrates
+ExecStart=/usr/bin/cgr-engine $DAEMON_OPTS
 KillMode=mixed
 User=cgrates
 Group=cgrates


### PR DESCRIPTION
This makes it more in line with the init script with requiring a systemd override for the service.