### PR TITLE
Fix logrotate configuration.

### DIFF
--- a/data/conf/logging/deb_logrotate.conf
+++ b/data/conf/logging/deb_logrotate.conf
@@ -6,6 +6,7 @@
         compress
         delaycompress
         sharedscripts
+        su root adm
         postrotate
 			/usr/lib/rsyslog/rsyslog-rotate
         endscript


### PR DESCRIPTION
logrotate refused to rotate the logfile due to permissions:
```
logrotate[6248]: error: skipping "/var/log/cgrates/CGRateS.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation
```
Ownership of the directory and logfile is root/adm:
```
total 192
drwxrwxr-x 2 root adm    4096 Jul 17 10:24 .
drwxr-xr-x 8 root root   4096 Jul 17 00:00 ..
-rw-r----- 1 root adm  182485 Jul 16 15:52 CGRateS.log
```