### PR TITLE
Packaging improvements

### DIFF
--- a/packages/Makefile
+++ b/packages/Makefile
@@ -1,7 +1,7 @@
 DISTRIBUTION ?= jessie
 
 GIT_COMMIT=$(shell git log -n1 --format=format:%h)
-GIT_DATE=$(shell date +%Y%m%d --date="@$(shell git log -n1 --format=format:%ct)")
+GIT_DATE=$(shell date +%Y%m%d%H%M%S --date="@$(shell git log -n1 --format=format:%ct)")
 
 ifeq ($(GIT_COMMIT),)
 	echo "Error: Failed to extract commit from git log"

--- a/packages/Makefile
+++ b/packages/Makefile
@@ -36,6 +36,7 @@ make deb:
 	dch -v "$(JESSIE_PKG_VERSION)" -m "Package build for git commit $(GIT_COMMIT) ($(GIT_DATE))." -D "$(DISTRIBUTION)" ;\
 	dpkg-buildpackage -rfakeroot -tc; \
 	rm debian
+	git checkout jessie/changelog
 
 make squeeze:
 	cd ..;\
@@ -43,5 +44,6 @@ make squeeze:
 	dch -v "$(SQUEEZE_PKG_VERSION)" -m "Package build for git commit $(GIT_COMMIT) ($(GIT_DATE))." -D "$(DISTRIBUTION)" ;\
 	dpkg-buildpackage -rfakeroot -tc; \
 	rm debian
+	git checkout squeeze/changelog
 
 .PHONY: deb squeeze


### PR DESCRIPTION
Because the modifications to the changelog file were not undone after building the package, the second build would use an incorrect version with the commit date and hash appended again. Now the changelog is checked out after the package build to undo the changes for the package build.

The package version only included the commit date which prevents package builds for multiple commits on that day (as the version won't be guaranteerd sequential), this is solved by including the time of the commit date as well.