### PR TITLE
TeoV Add LoaderSv1.Remove API

### DIFF
--- a/apier/v1/loaders.go
+++ b/apier/v1/loaders.go
@@ -43,6 +43,11 @@ func (ldrSv1 *LoaderSv1) Load(args *loaders.ArgsProcessFolder,
 	return ldrSv1.ldrS.V1Load(args, rply)
 }
 
+func (ldrSv1 *LoaderSv1) Remove(args *loaders.ArgsProcessFolder,
+	rply *string) error {
+	return ldrSv1.ldrS.V1Remove(args, rply)
+}
+
 func (rsv1 *LoaderSv1) Ping(ign *utils.CGREventWithArgDispatcher, reply *string) error {
 	*reply = utils.Pong
 	return nil

--- a/cmd/cgr-loader/cgr-loader.go
+++ b/cmd/cgr-loader/cgr-loader.go
@@ -69,7 +69,7 @@ var (
 		"The storDb user's password.")
 
 	cachingArg = cgrLoaderFlags.String("caching", "",
-		"Cache option to do when load tp")
+		"Caching strategy used when loading TP")
 	tpid = cgrLoaderFlags.String("tpid", dfltCfg.LoaderCgrCfg().TpID,
 		"The tariff plan ID from the database")
 	dataPath = cgrLoaderFlags.String("path", dfltCfg.LoaderCgrCfg().DataPath,

--- a/console/loader_remove.go
+++ b/console/loader_remove.go
@@ -1,0 +1,65 @@
+/*
+Real-time Online/Offline Charging System (OCS) for Telecom & ISP environments
+Copyright (C) ITsysCOM GmbH
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package console
+
+import (
+	"github.com/cgrates/cgrates/loaders"
+	"github.com/cgrates/cgrates/utils"
+)
+
+func init() {
+	c := &CmdLoaderRemove{
+		name:      "loader_remove",
+		rpcMethod: utils.LoaderSv1Remove,
+		rpcParams: &loaders.ArgsProcessFolder{},
+	}
+	commands[c.Name()] = c
+	c.CommandExecuter = &CommandExecuter{c}
+}
+
+type CmdLoaderRemove struct {
+	name      string
+	rpcMethod string
+	rpcParams *loaders.ArgsProcessFolder
+	*CommandExecuter
+}
+
+func (self *CmdLoaderRemove) Name() string {
+	return self.name
+}
+
+func (self *CmdLoaderRemove) RpcMethod() string {
+	return self.rpcMethod
+}
+
+func (self *CmdLoaderRemove) RpcParams(reset bool) interface{} {
+	if reset || self.rpcParams == nil {
+		self.rpcParams = &loaders.ArgsProcessFolder{}
+	}
+	return self.rpcParams
+}
+
+func (self *CmdLoaderRemove) PostprocessRpcParams() error {
+	return nil
+}
+
+func (self *CmdLoaderRemove) RpcResult() interface{} {
+	var s string
+	return &s
+}

--- a/loaders/libloader.go
+++ b/loaders/libloader.go
@@ -36,6 +36,13 @@ func (ld LoaderData) TenantID() string {
 	return utils.ConcatenatedKey(tnt, prflID)
 }
 
+func (ld LoaderData) TenantIDStruct() utils.TenantID {
+	return utils.TenantID{
+		Tenant: ld[utils.Tenant].(string),
+		ID:     ld[utils.ID].(string),
+	}
+}
+
 // UpdateFromCSV will update LoaderData with data received from fileName,
 // contained in record and processed with cfgTpl
 func (ld LoaderData) UpdateFromCSV(fileName string, record []string,

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -532,6 +532,7 @@ const (
 	MetaReload                  = "*reload"
 	MetaLoad                    = "*load"
 	MetaRemove                  = "*remove"
+	MetaStore                   = "*store"
 	MetaClear                   = "*clear"
 	LoadIDs                     = "load_ids"
 	DNSAgent                    = "DNSAgent"
@@ -976,9 +977,10 @@ const (
 
 // LoaderS APIs
 const (
-	LoaderSv1     = "LoaderSv1"
-	LoaderSv1Load = "LoaderSv1.Load"
-	LoaderSv1Ping = "LoaderSv1.Ping"
+	LoaderSv1       = "LoaderSv1"
+	LoaderSv1Load   = "LoaderSv1.Load"
+	LoaderSv1Remove = "LoaderSv1.Remove"
+	LoaderSv1Ping   = "LoaderSv1.Ping"
 )
 
 // CacheS APIs


### PR DESCRIPTION
LoaderSv1.Remove will read from a file( based on a template) line by line and when will find a complete item will delete it from the database and will release the memory. With this will prevent memory overload.