### PR TITLE
Don't fail when /etc/default/cgrates doesn't exist.

### DIFF
--- a/packages/debian/cgrates.service
+++ b/packages/debian/cgrates.service
@@ -7,7 +7,7 @@ After=network.target
 
 [Service]
 Type=simple
-EnvironmentFile=/etc/default/cgrates
+EnvironmentFile=-/etc/default/cgrates
 ExecStart=/usr/bin/cgr-engine $DAEMON_OPTS
 KillMode=mixed
 User=cgrates


### PR DESCRIPTION
It is not a typo as suggested in #1859.

See: https://www.freedesktop.org/software/systemd/man/systemd.exec.html#EnvironmentFile=