### PR TITLE
Fix panic with configurations with multiple event socket connections

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -76,6 +76,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @JDLK7 | Jose Domenech |
 | @mintos5 | Michal Škuta |
 | @playingbogart | Eugene Bozhet |
+| @htrendev | Hristo Trendev |
 
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |

--- a/agents/fsagent.go
+++ b/agents/fsagent.go
@@ -297,11 +297,11 @@ func (fsa *FSsessions) Connect() error {
 		}
 		fsa.conns[connIdx] = fSock
 		utils.Logger.Info(fmt.Sprintf("<%s> successfully connected to FreeSWITCH at: <%s>", utils.FreeSWITCHAgent, connCfg.Address))
-		go func() { // Start reading in own goroutine, return on error
-			if err := fsa.conns[connIdx].ReadEvents(); err != nil {
+		go func(fsock *fsock.FSock) { // Start reading in own goroutine, return on error
+			if err := fsock.ReadEvents(); err != nil {
 				errChan <- err
 			}
-		}()
+		}(fSock)
 		fsSenderPool, err := fsock.NewFSockPool(5, connCfg.Address, connCfg.Password, 1, fsa.cfg.MaxWaitConnection,
 			make(map[string][]func(string, int)), make(map[string][]string), utils.Logger.GetSyslog(), connIdx)
 		if err != nil {


### PR DESCRIPTION
This fixes a panic caused by a race when a configuration has more than one `event_socket_conns` server listed. In this case the for loop is executed more than once and the `connIdx` counter variable may get updated _before_  the go routine is actually stared.

I was able to replicated this 100% with two servers, when the second one is not reachable. The log below is from a binary from the stable branch, so the line numbers are off by one.

I'll provide another PR for the stable branch shortly.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x80 pc=0x12bb6fe]

goroutine 44 [running]:
github.com/cgrates/fsock.(*FSock).ReadEvents(0x0, 0x0, 0x0)
	/go/pkg/mod/github.com/cgrates/fsock@v0.0.0-20190623100231-317895b42f1a/fsock.go:278 +0x2e
github.com/cgrates/cgrates/agents.(*FSsessions).Connect.func1(0xc00042c3c0, 0xc00054c050, 0xc000564240)
	/repos/cgrates/agents/fsagent.go:300 +0x44
created by github.com/cgrates/cgrates/agents.(*FSsessions).Connect
	/repos/cgrates/agents/fsagent.go:299 +0x3a1
```