### PR TITLE
typo in consts.go - SCHEDULLER_NOT_RUNNING

### DIFF
--- a/utils/consts.go
+++ b/utils/consts.go
@@ -382,7 +382,7 @@ const (
 	ServiceAlreadyRunning    = "service already running"
 	RunningCaps              = "RUNNING"
 	StoppedCaps              = "STOPPED"
-	SchedulerNotRunningCaps  = "SCHEDULLER_NOT_RUNNING"
+	SchedulerNotRunningCaps  = "SCHEDULER_NOT_RUNNING"
 	MetaScheduler            = "*scheduler"
 	MetaSessionsCosts        = "*sessions_costs"
 	MetaRALs                 = "*rals"


### PR DESCRIPTION
should be SCHEDULER_NOT_RUNNING - super simple typo fix :)