### PR TITLE
ers docs typo

### DIFF
--- a/docs/ers.rst
+++ b/docs/ers.rst
@@ -46,7 +46,7 @@ With explanations in the comments:
 			],
 			"source_path": "/tmp/ers2/in",		// location of the files
 			"processed_path": "/tmp/ers2/out",	// move the files here once processed
-			"content_fields":[					// mapping definition between line index in the file and CGRateS field 
+			"fields":[					// mapping definition between line index in the file and CGRateS field 
 				{
 					"tag": "OriginID",			// OriginID together with OriginHost will 
 					"path": "*cgreq.OriginID",	//   uniquely identify the session on CGRateS side


### PR DESCRIPTION
references content_fields instead of fields which can cause an issue - this also needs to be fixed in the 0.10.x branch as well potentially, was unsure of process for a fix outside the master branch