### PR TITLE
Updated libsrtp-dev to libsrtp2-dev

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -81,6 +81,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @andronache98 | Andronache Andrei |
 | @ionutboangiu | Boangiu Silviu Ionut |
 | @nickolasdaniel | Filip Nickolas Daniel |
+| @JeremyC-AU | Jeremy Chequer |
 
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |

--- a/docs/tut_asterisk_installs.rst
+++ b/docs/tut_asterisk_installs.rst
@@ -15,7 +15,7 @@ Asterisk_
 We got Asterisk14_  installed via following commands:
 ::
 
- apt-get install autoconf build-essential openssl libssl-dev libsrtp-dev libxml2-dev libncurses5-dev uuid-dev sqlite3 libsqlite3-dev pkg-config libedit-dev
+ apt-get install autoconf build-essential openssl libssl-dev libsrtp2-dev libxml2-dev libncurses5-dev uuid-dev sqlite3 libsqlite3-dev pkg-config libedit-dev
  cd /tmp
  wget --no-check-certificate https://raw.githubusercontent.com/asterisk/third-party/master/pjproject/2.7.2/pjproject-2.7.2.tar.bz2
  wget --no-check-certificate https://raw.githubusercontent.com/asterisk/third-party/master/jansson/2.11/jansson-2.11.tar.bz2


### PR DESCRIPTION
Updated libsrtp-dev to libsrtp2-dev as libsrtp-dev is not longer available in the repository