### PR TITLE
Update MySQL Setup DB Script with command supported in later MySQL Versions

### DIFF
--- a/data/storage/mysql/create_db_with_users.sql
+++ b/data/storage/mysql/create_db_with_users.sql
@@ -5,5 +5,6 @@
 
 DROP DATABASE IF EXISTS cgrates;
 CREATE DATABASE cgrates;
-
-GRANT ALL on cgrates.* TO 'cgrates'@'localhost' IDENTIFIED BY 'CGRateS.org';
+CREATE USER 'cgrates'@'localhost' IDENTIFIED BY 'CGRateS.org';
+GRANT ALL PRIVILEGES ON cgrates.* TO 'cgrates'@'localhost' WITH GRANT OPTION;
+FLUSH PRIVILEGES;


### PR DESCRIPTION
MySQL 8 removes support for the ability to create a user and grant privileges in the same transaction / query, which was used by the ./setup_cgr_db.sh script.

This means that if you run the script on a MySQL 8 or later release you get:
```
root@cgr01:/usr/share/cgrates/storage/mysql# ./setup_cgr_db.sh root CGRateS.org localhost
mysql: [Warning] Using a password on the command line interface can be insecure.
ERROR 1064 (42000) at line 9: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'IDENTIFIED BY 'CGRateS.org'' at line 1
```

This is what we had before and works fine on older versions, but will not run on MySQL 8 and later:
`GRANT ALL on cgrates.* TO 'cgrates'@'localhost' IDENTIFIED BY 'CGRateS.org';`

Instead I have updated it to
```
CREATE USER 'cgrates'@'localhost' IDENTIFIED BY 'CGRateS.org';
GRANT ALL PRIVILEGES ON cgrates.* TO 'cgrates'@'localhost' WITH GRANT OPTION;
FLUSH PRIVILEGES;
```
Which should work across all versions of MySQL.