### PR TITLE
Use /etc/apt/trusted.gpg.d instead of apt-key.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,7 +35,7 @@ Add the gpg key:
 
 ::
 
-    sudo wget -O - https://apt.cgrates.org/apt.cgrates.org.gpg.key | sudo apt-key add -
+    sudo wget https://apt.cgrates.org/apt.cgrates.org.gpg.key -O /etc/apt/trusted.gpg.d/apt.cgrates.org.asc
 
 Add the repository in apt sources list:
 


### PR DESCRIPTION
As reported in https://github.com/cgrates/cgrates/issues/3705#issuecomment-1246264698, `apt-key` is deprecated, `/etc/apt/trusted.gpg.d` should be used instead.