### PR TITLE
Added check for explicit empty values in mailer config to allow SMTP without auth.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -85,6 +85,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @nickvsnetworking | Nick Jones |
 | @Eda91 | Edlira Eltari |
 | @gezimbll | Gezim Blliku|
+| @ruhnet | Ruel Tmeizeh |
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |
 -->

--- a/engine/action.go
+++ b/engine/action.go
@@ -402,7 +402,10 @@ func mailAsync(ub *Account, a *Action, acs Actions, _ *FilterS, extraData interf
 		}
 		message = []byte(fmt.Sprintf("To: %s\r\nSubject: [CGR Notification] Threshold hit on Balance: %s\r\n\r\nTime: \r\n\t%s\r\n\r\nBalance:\r\n\t%s\r\n\r\nYours faithfully,\r\nCGR Balance Monitor\r\n", toAddrStr, ub.ID, time.Now(), balJsn))
 	}
-	auth := smtp.PlainAuth("", cgrCfg.MailerCfg().MailerAuthUser, cgrCfg.MailerCfg().MailerAuthPass, strings.Split(cgrCfg.MailerCfg().MailerServer, ":")[0]) // We only need host part, so ignore port
+	var auth smtp.Auth
+	if len(cgrCfg.MailerCfg().MailerAuthUser) > 0 || len(cgrCfg.MailerCfg().MailerAuthPass) > 0 { //use auth if user/pass not empty in config
+		auth = smtp.PlainAuth("", cgrCfg.MailerCfg().MailerAuthUser, cgrCfg.MailerCfg().MailerAuthPass, strings.Split(cgrCfg.MailerCfg().MailerServer, ":")[0]) // We only need host part, so ignore port
+	}
 	go func() {
 		for i := 0; i < 5; i++ { // Loop so we can increase the success rate on best effort
 			if err := smtp.SendMail(cgrCfg.MailerCfg().MailerServer, auth, cgrCfg.MailerCfg().MailerFromAddr, toAddrs, message); err == nil {


### PR DESCRIPTION
If empty values are provided in the config for user/password, SMTP authentication will not be used when sending mails. This is useful when the mail server being utilized is localhost (or on a trusted network) and doesn't use authentication.