### PR TITLE
Revise CDR rerating

### DIFF
--- a/apier/v1/cdrs_it_test.go
+++ b/apier/v1/cdrs_it_test.go
@@ -237,12 +237,11 @@ func testV1CDRsProcessEventWithRefund(t *testing.T) {
 	}
 	if err := cdrsRpc.Call(utils.APIerSv2GetAccount, acntAttrs, &acnt); err != nil {
 		t.Error(err)
-	} else if blc1 := acnt.GetBalanceWithID(utils.MetaVoice, "BALANCE1"); blc1.Value != 120000000000 { // refund is done after debit
+	} else if blc1 := acnt.GetBalanceWithID(utils.MetaVoice, "BALANCE1"); blc1.Value != 60000000000 {
 		t.Errorf("Balance1 is: %s", utils.ToIJSON(blc1))
-	} else if blc2 := acnt.GetBalanceWithID(utils.MetaVoice, "BALANCE2"); blc2.Value != 120000000000 {
+	} else if blc2 := acnt.GetBalanceWithID(utils.MetaVoice, "BALANCE2"); blc2.Value != 180000000000 {
 		t.Errorf("Balance2 is: %s", utils.ToIJSON(blc2))
 	}
-	return
 }
 
 func testV1CDRsRefundOutOfSessionCost(t *testing.T) {


### PR DESCRIPTION
If the reRate parameter is set to true, also set the refund to true.

In case CostDetails is not populated, before attempting to refund try to retrieve it from StorDB.

Now that the refund happens before the debit, revise the expected values for the testV1CDRsProcessEventWithRefund subtest within the apier/v1/cdrs_it_test.go file.