### PR TITLE
Revise CDR rerating

### DIFF
--- a/apier/v2/cdrs_it_test.go
+++ b/apier/v2/cdrs_it_test.go
@@ -288,7 +288,7 @@ func testV2CDRsRateCDRs(t *testing.T) {
 
 	if err := cdrsRpc.Call(utils.CDRsV1RateCDRs, &engine.ArgRateCDRs{
 		RPCCDRsFilter: utils.RPCCDRsFilter{NotRunIDs: []string{"raw"}},
-		Flags:         []string{"*chargers:false"},
+		Flags:         []string{"*chargers:false", utils.MetaRerate},
 	}, &reply); err != nil {
 		t.Error("Unexpected error: ", err.Error())
 	} else if reply != utils.OK {
@@ -664,7 +664,7 @@ func testV2CDRsRateCDRsWithRatingPlan(t *testing.T) {
 
 	if err := cdrsRpc.Call(utils.CDRsV1RateCDRs, &engine.ArgRateCDRs{
 		RPCCDRsFilter: utils.RPCCDRsFilter{NotRunIDs: []string{"raw"}, Accounts: []string{"testV2CDRsProcessCDR4"}},
-		Flags:         []string{"*chargers:true"},
+		Flags:         []string{"*chargers:true", utils.MetaRerate},
 	}, &reply); err != nil {
 		t.Error("Unexpected error: ", err.Error())
 	} else if reply != utils.OK {

--- a/general_tests/rerate_cdrs_it_test.go
+++ b/general_tests/rerate_cdrs_it_test.go
@@ -339,7 +339,7 @@ func testRerateCDRsGetAccountAfterProcessEvent2(t *testing.T) {
 func testRerateCDRsRerateCDRs(t *testing.T) {
 	var reply string
 	if err := rrCdrsRPC.Call(utils.CDRsV1RateCDRs, &engine.ArgRateCDRs{
-		Flags: []string{utils.MetaRALs},
+		Flags: []string{utils.MetaRerate},
 		RPCCDRsFilter: utils.RPCCDRsFilter{
 			OrderBy: utils.AnswerTime,
 			CGRIDs:  []string{rrCdrsUUID},

--- a/general_tests/rerate_exp_it_test.go
+++ b/general_tests/rerate_exp_it_test.go
@@ -439,7 +439,7 @@ func testRerateExpGetAccountAfterProcessEvent3(t *testing.T) {
 func testRerateExpRerateCDRs(t *testing.T) {
 	var reply string
 	if err := ng2RPC.Call(utils.CDRsV1RateCDRs, &engine.ArgRateCDRs{
-		Flags: []string{utils.MetaRALs},
+		Flags: []string{utils.MetaRerate},
 		RPCCDRsFilter: utils.RPCCDRsFilter{
 			OrderBy: utils.AnswerTime,
 			CGRIDs:  []string{ng1UUID, ng2UUID},


### PR DESCRIPTION
If the reRate parameter is set to true, also set the refund to true.

In case CostDetails is not populated, retrieve it from StorDB if possible and add it to the CGREvent before converting to CDRs.

Now that the refund happens before the debit, revise the expected values for the testV1CDRsProcessEventWithRefund subtest within the apier/v1/cdrs_it_test.go file.