### PR TITLE
Improve cost formatting and parsing for CDRs

### DIFF
--- a/apier/v1/cdre_amqp_it_test.go
+++ b/apier/v1/cdre_amqp_it_test.go
@@ -165,7 +165,7 @@ func testAMQPMapAddCDRs(t *testing.T) {
 			AnswerTime:  time.Now(),
 			RunID:       utils.MetaDefault,
 			Usage:       time.Duration(30) * time.Second,
-			ExtraFields: map[string]string{"field_extr1": "val_extr1", "fieldextr2": "valextr2"},
+			ExtraFields: map[string]string{"RawCost": "0.17"},
 			Cost:        1.01,
 		},
 		{
@@ -233,7 +233,7 @@ func testAMQPMapVerifyExport(t *testing.T) {
 	}
 	expCDRs := []string{
 		`{"Account":"1001","CGRID":"Cdr2","Category":"call","Cost":"-1.0000","Destination":"+4986517174963","OriginID":"OriginCDR2","RunID":"*default","Source":"test2","Tenant":"cgrates.org","Usage":"5s"}`,
-		`{"Account":"1001","CGRID":"Cdr3","Category":"call","Cost":"-1.0000","Destination":"+4986517174963","OriginID":"OriginCDR3","RunID":"*default","Source":"test2","Tenant":"cgrates.org","Usage":"30s"}`,
+		`{"Account":"1001","CGRID":"Cdr3","Category":"call","Cost":"0.1700","Destination":"+4986517174963","OriginID":"OriginCDR3","RunID":"*default","Source":"test2","Tenant":"cgrates.org","Usage":"30s"}`,
 	}
 	rcvCDRs := make([]string, 0)
 	waiting := true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -565,7 +565,7 @@ func TestCgrCfgJSONDefaultsCdreProfiles(t *testing.T) {
 			Path:             "*exp.Cost",
 			Type:             "*composed",
 			Value:            NewRSRParsersMustCompile("~*req.Cost", true, utils.INFIELD_SEP),
-			RoundingDecimals: 4,
+			RoundingDecimals: utils.IntPointer(4),
 		},
 	}
 	for _, v := range eContentFlds {

--- a/config/fctemplate.go
+++ b/config/fctemplate.go
@@ -86,7 +86,8 @@ func NewFCTemplateFromFCTemplateJsonCfg(jsnCfg *FcTemplateJsonCfg, separator str
 		fcTmp.CostShiftDigits = *jsnCfg.Cost_shift_digits
 	}
 	if jsnCfg.Rounding_decimals != nil {
-		fcTmp.RoundingDecimals = *jsnCfg.Rounding_decimals
+		fcTmp.RoundingDecimals = new(int)
+		*fcTmp.RoundingDecimals = *jsnCfg.Rounding_decimals
 	}
 	if jsnCfg.Mask_destinationd_id != nil {
 		fcTmp.MaskDestID = *jsnCfg.Mask_destinationd_id
@@ -114,7 +115,7 @@ type FCTemplate struct {
 	BreakOnSuccess   bool
 	Layout           string // time format
 	CostShiftDigits  int    // Used for CDR
-	RoundingDecimals int
+	RoundingDecimals *int
 	MaskDestID       string
 	MaskLen          int
 	pathItems        utils.PathItems // Field identifier
@@ -196,7 +197,8 @@ func (fc *FCTemplate) Clone() *FCTemplate {
 	cln.BreakOnSuccess = fc.BreakOnSuccess
 	cln.Layout = fc.Layout
 	cln.CostShiftDigits = fc.CostShiftDigits
-	cln.RoundingDecimals = fc.RoundingDecimals
+	cln.RoundingDecimals = new(int)
+	*cln.RoundingDecimals = *fc.RoundingDecimals
 	cln.MaskDestID = fc.MaskDestID
 	cln.MaskLen = fc.MaskLen
 	return cln
@@ -261,8 +263,8 @@ func (fc *FCTemplate) AsMapInterface(separator string) (mp map[string]interface{
 	if fc.CostShiftDigits != 0 {
 		mp[utils.CostShiftDigitsCfg] = fc.CostShiftDigits
 	}
-	if fc.RoundingDecimals != 0 {
-		mp[utils.RoundingDecimalsCfg] = fc.RoundingDecimals
+	if fc.RoundingDecimals != nil {
+		mp[utils.RoundingDecimalsCfg] = *fc.RoundingDecimals
 	}
 	if fc.MaskDestID != utils.EmptyString {
 		mp[utils.MaskDestIDCfg] = fc.MaskDestID

--- a/config/rsrparser.go
+++ b/config/rsrparser.go
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 package config
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -317,4 +318,18 @@ func (prsr *RSRParser) ParseDataProviderWithInterfaces(dP utils.DataProvider, se
 		}
 	}
 	return prsr.ParseValue(outIface)
+}
+
+// ParseDataProviderAsFloat64 retrieves a field from the provided DataProvider and attempts
+// to parse it as a float64.
+func (prsr *RSRParser) ParseDataProviderAsFloat64(dP utils.DataProvider, separator string) (float64, error) {
+	if prsr.path == "" {
+		// If the path is empty, we cannot retrieve any data.
+		return 0, errors.New("empty path in parser")
+	}
+	outIface, err := dP.FieldAsInterface(strings.Split(prsr.path, separator))
+	if err != nil && (err != utils.ErrNotFound || prsr.filters.FilterRules() != "^$") {
+		return 0, err
+	}
+	return utils.IfaceAsFloat64(outIface)
 }

--- a/data/conf/samples/cdre/cgrates.json
+++ b/data/conf/samples/cdre/cgrates.json
@@ -47,7 +47,8 @@
             {"path": "*exp.Account", "type": "*composed", "value": "~*req.Account"},
             {"path": "*exp.Destination", "type": "*composed", "value": "~*req.Destination"},
             {"path": "*exp.Usage", "type": "*composed", "value": "~*req.Usage"},
-            {"path": "*exp.Cost", "type": "*composed", "value": "~*req.Cost", "rounding_decimals": 4}
+            {"path": "*exp.Cost", "type": "*composed", "filters": ["*notstring:~*req.CGRID:Cdr3"], "value": "~*req.Cost", "rounding_decimals": 4},
+            {"path": "*exp.Cost", "type": "*variable", "filters": ["*string:~*req.CGRID:Cdr3"], "value": "~*req.RawCost", "rounding_decimals": 4}
         ]
     },
     "amqp_exporter_cdr": {

--- a/engine/cdr.go
+++ b/engine/cdr.go
@@ -327,8 +327,12 @@ func (cdr *CDR) exportFieldValue(cfgCdrFld *config.FCTemplate, filterS *FilterS)
 		var cdrVal string
 		switch cfgCdrFld.Path {
 		case utils.MetaExp + utils.NestingSep + utils.COST:
+			roundingDecimals := config.CgrConfig().GeneralCfg().RoundingDecimals
+			if cfgCdrFld.RoundingDecimals != nil {
+				roundingDecimals = *cfgCdrFld.RoundingDecimals
+			}
 			cdrVal, err = cdr.FormatCost(rsrFld, cfgCdrFld.CostShiftDigits,
-				cfgCdrFld.RoundingDecimals)
+				roundingDecimals)
 			if err != nil {
 				return
 			}

--- a/engine/cdrecsv_test.go
+++ b/engine/cdrecsv_test.go
@@ -187,7 +187,7 @@ func TestExportVoiceWithConvert(t *testing.T) {
 			Path:             "*exp.Cost",
 			Type:             "*composed",
 			Value:            config.NewRSRParsersMustCompile(utils.DynamicDataPrefix+utils.MetaReq+utils.NestingSep+"Cost", true, utils.INFIELD_SEP),
-			RoundingDecimals: 5},
+			RoundingDecimals: utils.IntPointer(5)},
 	}
 	cdrVoice := &CDR{
 		CGRID: utils.Sha1("dsafdsaf", time.Unix(1383813745, 0).UTC().String()),
@@ -326,7 +326,7 @@ func TestExportWithFilter(t *testing.T) {
 			Path:             "*exp.Cost",
 			Type:             "*composed",
 			Value:            config.NewRSRParsersMustCompile(utils.DynamicDataPrefix+utils.MetaReq+utils.NestingSep+"Cost", true, utils.INFIELD_SEP),
-			RoundingDecimals: 5},
+			RoundingDecimals: utils.IntPointer(5)},
 	}
 	cdrVoice := &CDR{
 		CGRID: utils.Sha1("dsafdsaf", time.Unix(1383813745, 0).UTC().String()),
@@ -464,7 +464,7 @@ func TestExportWithFilter2(t *testing.T) {
 			Path:             "*exp.Cost",
 			Type:             "*composed",
 			Value:            config.NewRSRParsersMustCompile(utils.DynamicDataPrefix+utils.MetaReq+utils.NestingSep+"Cost", true, utils.INFIELD_SEP),
-			RoundingDecimals: 5},
+			RoundingDecimals: utils.IntPointer(5)},
 	}
 	cdrVoice := &CDR{
 		CGRID: utils.Sha1("dsafdsaf", time.Unix(1383813745, 0).UTC().String()),


### PR DESCRIPTION
The FormatCost function in cdr.go now accepts an additional parameter of type *config.RSRParser. This is then used to extract the value from its path as opposed to always using the value of the Cost field directly.

Improved the unit test for the FormatCost function. Now it has become a table-driven test and it handles cases when the cost is retrieved from different fields other than  from the CDR.