### PR TITLE
Check if RoundingDecimals is nil before loading

### DIFF
--- a/config/fctemplate.go
+++ b/config/fctemplate.go
@@ -197,8 +197,10 @@ func (fc *FCTemplate) Clone() *FCTemplate {
 	cln.BreakOnSuccess = fc.BreakOnSuccess
 	cln.Layout = fc.Layout
 	cln.CostShiftDigits = fc.CostShiftDigits
-	cln.RoundingDecimals = new(int)
-	*cln.RoundingDecimals = *fc.RoundingDecimals
+	if fc.RoundingDecimals != nil {
+		cln.RoundingDecimals = new(int)
+		*cln.RoundingDecimals = *fc.RoundingDecimals
+	}
 	cln.MaskDestID = fc.MaskDestID
 	cln.MaskLen = fc.MaskLen
 	return cln


### PR DESCRIPTION
This prevents the nil pointer dereference panic occuring when not set it is not set.