### PR TITLE
Activate privilege escalation for removing go installation

### DIFF
--- a/data/ansible/roles/go/tasks/main.yaml
+++ b/data/ansible/roles/go/tasks/main.yaml
@@ -6,6 +6,7 @@
   changed_when: false
 
 - name: Remove current installation.
+  become: yes
   file:
     state: absent
     path: /usr/local/go


### PR DESCRIPTION
To remove files from /usr/local/go, root privileges are required.