### PR TITLE
Fix spelling errors.

### DIFF
--- a/agents/diamagent.go
+++ b/agents/diamagent.go
@@ -145,7 +145,7 @@ func (da *DiameterAgent) handlers() diam.Handler {
 	if len(hosts) == 0 {
 		interfaces, err := net.Interfaces()
 		if err != nil {
-			utils.Logger.Err(fmt.Sprintf("<%s> error : %v, when quering interfaces for address", utils.DiameterAgent, err))
+			utils.Logger.Err(fmt.Sprintf("<%s> error : %v, when querying interfaces for address", utils.DiameterAgent, err))
 		}
 		for _, inter := range interfaces {
 			addrs, err := inter.Addrs()

--- a/agents/fsagent.go
+++ b/agents/fsagent.go
@@ -361,7 +361,7 @@ func (fsa *FSsessions) disconnectSession(connIdx int, uuid, redirectNr, notify s
 	if err := fsa.conns[connIdx].SendMsgCmd(uuid,
 		map[string]string{"call-command": "hangup", "hangup-cause": "MANAGER_REQUEST"}); err != nil {
 		utils.Logger.Err(
-			fmt.Sprintf("<%s> Could not send disconect msg to freeswitch, error: <%s>, connIdx: %v",
+			fmt.Sprintf("<%s> Could not send disconnect msg to freeswitch, error: <%s>, connIdx: %v",
 				utils.FreeSWITCHAgent, err.Error(), connIdx))
 		return err
 	}

--- a/config/config_defaults.go
+++ b/config/config_defaults.go
@@ -168,7 +168,7 @@ const CGRATES_CFG_JSON = `
 		"mysqlDSNParams": {},               // DSN extra paramss
 		"mongoQueryTimeout": "10s",			// timeout for query when mongo is used
 		"pgSSLMode": "disable",		 		// pgSSLMode in case of *postgres
-		"mysqlLocation": "Local",			// the location the time from mysql is retrived
+		"mysqlLocation": "Local",			// the location the time from mysql is retrieved
 	},
 	"items":{
 		"*session_costs": {"limit": -1, "ttl": "", "static_ttl": false, "remote":false, "replicate":false}, 
@@ -593,7 +593,7 @@ const CGRATES_CFG_JSON = `
 				// "caPath": "",  								// path to CA certificate
 				// "tls": false, 								//
 				// "connIDs": [],  								// connections for connManager to this exporter
-				// "rpcConnTimeout" : "1s", 					// connection unsuccesfull on timeout
+				// "rpcConnTimeout" : "1s", 					// connection unsuccessful on timeout
 				// "rpcReplyTimeout":"2s", 						// connection down at replies if taking longer that this value
 				// "rpcAPIOpts": {},
 			},													// extra options for exporter

--- a/cores/server.go
+++ b/cores/server.go
@@ -293,7 +293,7 @@ func acceptBiRPC(srv *birpc.BirpcServer, l net.Listener, codecName string, newCo
 				return
 			}
 			stopBiRPCServer <- struct{}{}
-			utils.Logger.Crit(fmt.Sprintf("Stopped Bi%s server beacause %s", codecName, err))
+			utils.Logger.Crit(fmt.Sprintf("Stopped Bi%s server because %s", codecName, err))
 			return // stop if we get Accept error
 		}
 		go srv.ServeCodec(newCodec(conn))

--- a/data/conf/cgrates/cgrates.json
+++ b/data/conf/cgrates/cgrates.json
@@ -139,7 +139,7 @@
 // 		"sqlConnMaxLifetime": 0, 			// maximum amount of time in seconds a connection may be reused (0 for unlimited), not applying for mongo
 // 		"mongoQueryTimeout":"10s",			// timeout for query when mongo is used
 // 		"postgresSSLMode":"disable",		// postgresSSLMode in case of *postgres
-// 		"mysqlLocation": "Local",			// the location the time from mysql is retrived
+// 		"mysqlLocation": "Local",			// the location the time from mysql is retrieved
 // 	},
 // 	"items":{
 // 		"*session_costs": {"limit": -1, "ttl": "", "static_ttl": false, "remote":false, "replicate":false}, 

--- a/ees/ees.go
+++ b/ees/ees.go
@@ -200,7 +200,7 @@ func (eeS *EventExporterS) V1ProcessEvent(ctx *context.Context, cgrEv *engine.CG
 		// log the message before starting the gorutine, but still execute the exporter
 		if hasVerbose && !eeCfg.Synchronous {
 			utils.Logger.Warning(
-				fmt.Sprintf("<%s> with id <%s>, running verbosed exporter with syncronous false",
+				fmt.Sprintf("<%s> with id <%s>, running verbosed exporter with synchronous false",
 					utils.EEs, ee.Cfg().ID))
 		}
 		go func(evict, sync bool, ee EventExporter) {

--- a/engine/storage_mongo_datadb.go
+++ b/engine/storage_mongo_datadb.go
@@ -398,10 +398,10 @@ func (ms *MongoStorage) EnsureIndexes(cols ...string) (err error) {
 	return
 }
 
-// Close disconects the client
+// Close disconnects the client
 func (ms *MongoStorage) Close() {
 	if err := ms.client.Disconnect(ms.ctx); err != nil {
-		utils.Logger.Err(fmt.Sprintf("<MongoStorage> Error on disconect:%s", err))
+		utils.Logger.Err(fmt.Sprintf("<MongoStorage> Error on disconnect:%s", err))
 	}
 }
 

--- a/engine/thresholds.go
+++ b/engine/thresholds.go
@@ -283,7 +283,7 @@ func (tS *ThresholdService) storeThresholds() {
 		}
 		tIf, ok := Cache.Get(utils.CacheThresholds, tID)
 		if !ok || tIf == nil {
-			utils.Logger.Warning(fmt.Sprintf("<ThresholdS> failed retrieving from cache treshold with ID: %s", tID))
+			utils.Logger.Warning(fmt.Sprintf("<ThresholdS> failed retrieving from cache threshold with ID: %s", tID))
 			continue
 		}
 		t := tIf.(*Threshold)

--- a/engine/thresholds_test.go
+++ b/engine/thresholds_test.go
@@ -814,7 +814,7 @@ func TestThresholdsStoreThresholdsCacheGetErr(t *testing.T) {
 	Cache.SetWithoutReplicate(utils.CacheThresholds, "TH2", value, nil, true,
 		utils.NonTransactional)
 	tS.storedTdIDs.Add("TH1")
-	expLog := `[WARNING] <ThresholdS> failed retrieving from cache treshold with ID: TH1`
+	expLog := `[WARNING] <ThresholdS> failed retrieving from cache threshold with ID: TH1`
 	tS.storeThresholds()
 
 	if rcvLog := buf.String(); !strings.Contains(rcvLog, expLog) {

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -559,7 +559,7 @@ func (sS *SessionS) debitLoopSession(s *Session, sRunIdx int,
 			if err.Error() == utils.ErrUnauthorizedDestination.Error() {
 				dscReason = err.Error()
 			}
-			// try to disconect the session n times before we force terminate it on our side
+			// try to disconnect the session n times before we force terminate it on our side
 			fib := utils.FibDuration(time.Millisecond, 0)
 			for i := 0; i < sS.cgrCfg.SessionSCfg().TerminateAttempts; i++ {
 				if i != 0 { // not the first iteration
@@ -598,7 +598,7 @@ func (sS *SessionS) debitLoopSession(s *Session, sRunIdx int,
 			case <-time.After(maxDebit):
 				s.Lock()
 				defer s.Unlock()
-				// try to disconect the session n times before we force terminate it on our side
+				// try to disconnect the session n times before we force terminate it on our side
 				fib := utils.FibDuration(time.Millisecond, 0)
 				for i := 0; i < sS.cgrCfg.SessionSCfg().TerminateAttempts; i++ {
 					if i != 0 { // not the first iteration
@@ -1393,11 +1393,11 @@ func (sS *SessionS) syncSessions() {
 		case err = <-errChan:
 			if err != nil && err.Error() != utils.ErrNoActiveSession.Error() {
 				utils.Logger.Warning(
-					fmt.Sprintf("<%s> error <%s> quering session ids", utils.SessionS, err.Error()))
+					fmt.Sprintf("<%s> error <%s> querying session ids", utils.SessionS, err.Error()))
 			}
 		case <-time.After(sS.cgrCfg.GeneralCfg().ReplyTimeout):
 			utils.Logger.Warning(
-				fmt.Sprintf("<%s> timeout quering session ids ", utils.SessionS))
+				fmt.Sprintf("<%s> timeout querying session ids ", utils.SessionS))
 		}
 	}
 	var toBeRemoved []string


### PR DESCRIPTION
The lintian QA tool reported spelling errors for the Debian package build:

 * beacause     -> because
 * disconect    -> disconnect
 * quering      -> querying
 * retrived     -> retrieved
 * syncronous   -> synchronous
 * treshold     -> threshold
 * unsuccesfull -> unsuccessful