### PR TITLE
fix: typo in rjreader.go

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -88,6 +88,7 @@ information, please see the [`CONTRIBUTING.md`](CONTRIBUTING.md) file.
 | @ruhnet | Ruel Tmeizeh |
 | @arberkatellari | Arber Katellari |
 | @Juneezee | Eng Zer Jun |
+| @varundhand | Varun Dhand |
 <!-- to sign, include a single line above this comment containing the following text:
 | @username | First Last |
 -->

--- a/config/rjreader.go
+++ b/config/rjreader.go
@@ -54,7 +54,7 @@ func isWhiteSpace(c byte) bool {
 	return c == ' ' || c == '\t' || isNewLine(c) || c == 0
 }
 
-// ReadEnv reads the enviorment variable
+// ReadEnv reads the enviornment variable
 func ReadEnv(key string) (string, error) { //it shod print a warning not a error
 	if env := os.Getenv(key); env != "" {
 		return env, nil
@@ -239,7 +239,7 @@ func (rjr *RjReader) checkMeta() bool {
 		utils.MetaEnv == string(rjr.buf[rjr.indx-1:rjr.indx-1+len(utils.MetaEnv)])
 }
 
-// readEnvName reads the enviorment key
+// readEnvName reads the enviornment key
 func (rjr *RjReader) readEnvName(indx int) (name []byte, endindx int) { //0 if not set
 	for indx < len(rjr.buf) { //read byte by byte
 		bit := rjr.buf[indx]
@@ -252,7 +252,7 @@ func (rjr *RjReader) readEnvName(indx int) (name []byte, endindx int) { //0 if n
 	return name, indx
 }
 
-// replaceEnv replaces the EnvMeta and enviorment key with  enviorment variable value in specific buffer
+// replaceEnv replaces the EnvMeta and enviornment key with  enviornment variable value in specific buffer
 func (rjr *RjReader) replaceEnv(startEnv int) error {
 	midEnv := len(utils.MetaEnv)
 	key, endEnv := rjr.readEnvName(startEnv + midEnv)

--- a/config/rjreader.go
+++ b/config/rjreader.go
@@ -54,7 +54,7 @@ func isWhiteSpace(c byte) bool {
 	return c == ' ' || c == '\t' || isNewLine(c) || c == 0
 }
 
-// ReadEnv reads the enviornment variable
+// ReadEnv reads the environment variable
 func ReadEnv(key string) (string, error) { //it shod print a warning not a error
 	if env := os.Getenv(key); env != "" {
 		return env, nil
@@ -239,7 +239,7 @@ func (rjr *RjReader) checkMeta() bool {
 		utils.MetaEnv == string(rjr.buf[rjr.indx-1:rjr.indx-1+len(utils.MetaEnv)])
 }
 
-// readEnvName reads the enviornment key
+// readEnvName reads the environment key
 func (rjr *RjReader) readEnvName(indx int) (name []byte, endindx int) { //0 if not set
 	for indx < len(rjr.buf) { //read byte by byte
 		bit := rjr.buf[indx]
@@ -252,7 +252,7 @@ func (rjr *RjReader) readEnvName(indx int) (name []byte, endindx int) { //0 if n
 	return name, indx
 }
 
-// replaceEnv replaces the EnvMeta and enviornment key with  enviornment variable value in specific buffer
+// replaceEnv replaces the EnvMeta and environment key with  environment variable value in specific buffer
 func (rjr *RjReader) replaceEnv(startEnv int) error {
 	midEnv := len(utils.MetaEnv)
 	key, endEnv := rjr.readEnvName(startEnv + midEnv)


### PR DESCRIPTION
This PR fixes typos in **cgrates/config/rjreader.go** file.

Following typos have been fixed:

`enviorment` -> `environment`

No other changes.