### PR TITLE
Revise buildURL function

### DIFF
--- a/engine/storage_mongo_datadb.go
+++ b/engine/storage_mongo_datadb.go
@@ -156,7 +156,7 @@ func NewMongoStorage(host, port, db, user, pass, mrshlerStr string, storageType 
 		storageType: storageType,
 		counter:     utils.NewCounter(time.Now().UnixNano(), 0),
 	}
-	uri := composeURI("mongodb", host, port, db, user, pass)
+	uri := composeMongoURI("mongodb", host, port, db, user, pass)
 	reg := bson.NewRegistry()
 	decimalType := reflect.TypeOf(utils.Decimal{})
 	reg.RegisterTypeEncoder(decimalType, bsoncodec.ValueEncoderFunc(decimalEncoder))

--- a/engine/storage_test.go
+++ b/engine/storage_test.go
@@ -281,7 +281,7 @@ func TestComposeURI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			url := composeURI(tt.scheme, tt.host, tt.port, tt.db, tt.user, tt.pass)
+			url := composeMongoURI(tt.scheme, tt.host, tt.port, tt.db, tt.user, tt.pass)
 			if url != tt.expected {
 				t.Errorf("expected %v,\nreceived %v", tt.expected, url)
 			}

--- a/engine/storage_test.go
+++ b/engine/storage_test.go
@@ -204,3 +204,87 @@ func TestStorageDecodeCodecMsgpackMarshaler(t *testing.T) {
 		})
 	}
 }
+
+func TestComposeURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		scheme   string
+		host     string
+		port     string
+		db       string
+		user     string
+		pass     string
+		expected string
+		parseErr bool
+	}{
+		{
+			name:     "multiple nodes",
+			scheme:   "mongodb",
+			host:     "clusternode1:1230,clusternode2:1231,clusternode3",
+			port:     "1232",
+			db:       "cgrates",
+			user:     "user",
+			pass:     "pass",
+			expected: "mongodb://user:pass@clusternode1:1230,clusternode2:1231,clusternode3:1232/cgrates",
+		},
+		{
+			name:     "no port",
+			scheme:   "mongodb",
+			host:     "localhost:1234",
+			port:     "0",
+			db:       "cgrates",
+			user:     "user",
+			pass:     "pass",
+			expected: "mongodb://user:pass@localhost:1234/cgrates",
+		},
+		{
+			name:     "with port",
+			scheme:   "mongodb",
+			host:     "localhost",
+			port:     "1234",
+			db:       "cgrates",
+			user:     "user",
+			pass:     "pass",
+			expected: "mongodb://user:pass@localhost:1234/cgrates",
+		},
+		{
+			name:     "no password",
+			scheme:   "mongodb",
+			host:     "localhost",
+			port:     "1234",
+			db:       "cgrates",
+			user:     "user",
+			pass:     "",
+			expected: "mongodb://localhost:1234/cgrates",
+		},
+		{
+			name:     "no db",
+			scheme:   "mongodb",
+			host:     "localhost",
+			port:     "1234",
+			db:       "",
+			user:     "user",
+			pass:     "pass",
+			expected: "mongodb://user:pass@localhost:1234",
+		},
+		{
+			name:     "different scheme",
+			scheme:   "mongodb+srv",
+			host:     "cgr.abcdef.mongodb.net",
+			port:     "0",
+			db:       "?retryWrites=true&w=majority",
+			user:     "user",
+			pass:     "pass",
+			expected: "mongodb+srv://user:pass@cgr.abcdef.mongodb.net/?retryWrites=true&w=majority",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url := composeURI(tt.scheme, tt.host, tt.port, tt.db, tt.user, tt.pass)
+			if url != tt.expected {
+				t.Errorf("expected %v,\nreceived %v", tt.expected, url)
+			}
+		})
+	}
+}

--- a/engine/storage_utils.go
+++ b/engine/storage_utils.go
@@ -80,7 +80,17 @@ func NewStorDBConn(dbType, host, port, name, user, pass, marshaler string,
 	return
 }
 
-func composeURI(scheme, host, port, db, user, pass string) string {
+// composeMongoURI constructs a MongoDB URI from the given parameters:
+//   - scheme: only "mongodb" for now.
+//   - host: MongoDB server host (e.g., "localhost").
+//   - port: MongoDB server port, excluded if "0".
+//   - db: Database name, may include additional parameters (e.g., "db?retryWrites=true").
+//   - user: Username for auth, omitted if empty.
+//   - pass: Password for auth, only if username is set.
+//
+// TODO: Decide whether to replace the 'scheme' string parameter with a boolean once support
+// for "mongodb+srv" is added.
+func composeMongoURI(scheme, host, port, db, user, pass string) string {
 	uri := scheme + "://"
 	if user != "" && pass != "" {
 		uri += user + ":" + pass + "@"

--- a/engine/storage_utils.go
+++ b/engine/storage_utils.go
@@ -20,9 +20,6 @@ package engine
 
 import (
 	"fmt"
-	"net"
-	"net/url"
-	"path"
 	"strconv"
 	"strings"
 
@@ -83,20 +80,18 @@ func NewStorDBConn(dbType, host, port, name, user, pass, marshaler string,
 	return
 }
 
-func buildURL(scheme, host, port, db, user, pass string) (*url.URL, error) {
-	u, err := url.Parse("//" + host)
-	if err != nil {
-		return nil, err
-	}
-	if port != "0" {
-		u.Host = net.JoinHostPort(u.Host, port)
-	}
+func composeURI(scheme, host, port, db, user, pass string) string {
+	uri := scheme + "://"
 	if user != "" && pass != "" {
-		u.User = url.UserPassword(user, pass)
+		uri += user + ":" + pass + "@"
+	}
+	uri += host
+	if port != "0" {
+		uri += ":" + port
+
 	}
 	if db != "" {
-		u.Path = path.Join(u.Path, db)
+		uri += "/" + db
 	}
-	u.Scheme = scheme
-	return u, nil
+	return uri
 }


### PR DESCRIPTION
Renamed to composeURI.

Use simple string concatenation to build URI because there is no need to keep the Parse call as a validation step. Any issue would be caught when establishing a connection.