### PR TITLE
Update *alter_sessions action

### DIFF
--- a/agents/radius_coa_it_test.go
+++ b/agents/radius_coa_it_test.go
@@ -102,7 +102,7 @@ func TestRadiusCoADisconnect(t *testing.T) {
 			ActionsId: "ACT_RAD_COA_ACNT_1001",
 			Actions: []*utils.TPAction{{
 				Identifier:      utils.MetaAlterSessions,
-				ExtraParameters: "cgrates.org;*string:~*req.Account:1001;1;*radCoATemplate:mycoa;CustomFilter:custom_filter",
+				ExtraParameters: "localhost:2012;*json;cgrates.org;*string:~*req.Account:1001;1;*radCoATemplate:mycoa;CustomFilter:custom_filter",
 			}}}
 		if err := raDiscRPC.Call(context.Background(), utils.APIerSv2SetActions,
 			actRadCoaAcnt1001, &reply); err != nil {
@@ -279,6 +279,6 @@ func TestRadiusCoADisconnect(t *testing.T) {
 	select {
 	case <-done:
 	case <-time.After(time.Second):
-		t.Error("client did not receive a the expected requests in time")
+		t.Error("client did not receive the expected requests in time")
 	}
 }

--- a/analyzers/analyzers_it_test.go
+++ b/analyzers/analyzers_it_test.go
@@ -123,7 +123,7 @@ func testAnalyzerSStartEngine(t *testing.T) {
 
 // Connect rpc client to rater
 func testAnalyzerSRPCConn(t *testing.T) {
-	srv, err := birpc.NewService(new(smock), utils.SessionSv1, true)
+	srv, err := birpc.NewService(new(smock), utils.AgentV1, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apier/v1/sessions_thresholds_it_test.go
+++ b/apier/v1/sessions_thresholds_it_test.go
@@ -126,7 +126,7 @@ func testSessionSv1ItRpcConn(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := birpc.NewService(new(smock2), utils.SessionSv1, true)
+	srv, err := birpc.NewService(new(smock2), utils.AgentV1, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/apier/v1/sessionsv1_it_test.go
+++ b/apier/v1/sessionsv1_it_test.go
@@ -167,7 +167,7 @@ func testSSv1ItRpcConn(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := birpc.NewService(new(smock), utils.SessionSv1, true)
+	srv, err := birpc.NewService(new(smock), utils.AgentV1, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/cgr-tester/sessions.go
+++ b/cmd/cgr-tester/sessions.go
@@ -74,7 +74,7 @@ func callSessions(ctx *context.Context, authDur, initDur, updateDur, terminateDu
 		APIOpts: map[string]any{},
 	}
 
-	srv, err := birpc.NewService(new(smock), utils.SessionSv1, true)
+	srv, err := birpc.NewService(new(smock), utils.AgentV1, true)
 	if err != nil {
 		return err
 	}

--- a/data/tariffplans/oldtutorial/Actions.csv
+++ b/data/tariffplans/oldtutorial/Actions.csv
@@ -11,4 +11,4 @@ DISABLE_AND_LOG,*log,,,,,,,,,,,,,false,false,10
 DISABLE_AND_LOG,*disable_account,,,,,,,,,,,,,false,false,10
 TOPUP_100SMS_DE_MOBILE,*topup,,,,*sms,,DST_DE_MOBILE,,,,,100,10,false,false,10
 #ACT_RAD_COA_ACNT_1001,*cgr_rpc,"{""Address"":""localhost:2012"",""Transport"":""*json"",""Method"":""SessionSv1.AlterSessions"",""Attempts"":1,""Async"":false,""Params"":{""Filters"":[""*string:~*req.Account:1001""],""Tenant"":""cgrates.org"",""APIOpts"":{""*radCoATemplate"":""mycoa""},""Event"":{""CustomFilter"":""custom_filter""}}}",,,,,,,,,,,,,,20
-ACT_RAD_COA_ACNT_1001,*alter_sessions,cgrates.org;*string:~*req.Account:1001;1;*radCoATemplate:mycoa;CustomFilter:mycustomvalue,,,,,,,,,,,,,,
+ACT_RAD_COA_ACNT_1001,*alter_sessions,localhost:2012;*json;cgrates.org;*string:~*req.Account:1001;1;*radCoATemplate:mycoa;CustomFilter:mycustomvalue,,,,,,,,,,,,,,

--- a/sessions/sessions_birpc_it_test.go
+++ b/sessions/sessions_birpc_it_test.go
@@ -113,7 +113,7 @@ func testSessionsBiRPCStartEngine(t *testing.T) {
 
 // Connect rpc client to rater
 func testSessionsBiRPCApierRpcConn(t *testing.T) {
-	srv, err := birpc.NewService(new(smock), utils.SessionSv1, true)
+	srv, err := birpc.NewService(new(smock), utils.AgentV1, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils/rpc_params.go
+++ b/utils/rpc_params.go
@@ -21,6 +21,7 @@ package utils
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/cgrates/birpc"
@@ -85,4 +86,15 @@ func GetRpcParams(method string) (params *RpcParams, err error) {
 		return nil, ErrNotFound
 	}
 	return
+}
+
+func UnregisterRpcParams(name string) {
+	rpcParamsLock.Lock()
+	defer rpcParamsLock.Unlock()
+	for method := range rpcParamsMap {
+		if strings.HasPrefix(method, name) {
+			delete(rpcParamsMap, method)
+		}
+	}
+	delete(rpcParamsMap, name)
 }


### PR DESCRIPTION
Will now support two extra parameters: address and codec. For *internal connections, the birpc.Service object will be retrieved from rpcParamsMap from utils. Supported codecs: <*gob|*json|*http_jsonrpc> (ingored for *internal address).

Action does not bother with setting defaults anymore, lets the API handle them.

Improve action comments.

Add unit tests for the action. UnregisterRpcParams' implementation was required.

Updated *alter_sessions action tariffplan for radius coa integration test to include address and codec.

Some birpc clients that are set up in integration tests were still registering a SessionSv1 object. Updated them to register an AgentV1 object instead.