### PR TITLE
Add custom CGREvent UnmarshalJSON method

### DIFF
--- a/engine/argees_test.go
+++ b/engine/argees_test.go
@@ -1,0 +1,130 @@
+/*
+Real-time Online/Offline Charging System (OCS) for Telecom & ISP environments
+Copyright (C) ITsysCOM GmbH
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cgrates/cgrates/utils"
+)
+
+func TestArgEEsUnmarshalJSON(t *testing.T) {
+	var testEC = &EventCost{
+		CGRID:     "164b0422fdc6a5117031b427439482c6a4f90e41",
+		RunID:     utils.MetaDefault,
+		StartTime: time.Date(2017, 1, 9, 16, 18, 21, 0, time.UTC),
+		AccountSummary: &AccountSummary{
+			Tenant: "cgrates.org",
+			ID:     "dan",
+			BalanceSummaries: []*BalanceSummary{
+				{
+					UUID:     "8c54a9e9-d610-4c82-bcb5-a315b9a65010",
+					ID:       "BALANCE_1",
+					Type:     utils.MetaMonetary,
+					Value:    50,
+					Initial:  60,
+					Disabled: false,
+				},
+			},
+			AllowNegative: false,
+			Disabled:      false,
+		},
+	}
+	cdBytes, err := json.Marshal(testEC)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cgrEvWithIDs := CGREventWithEeIDs{
+		EeIDs: []string{"id1", "id2"},
+		CGREvent: &CGREvent{
+			Tenant: "cgrates.org",
+			ID:     "ev1",
+			Event: map[string]any{
+				utils.AccountField: "1001",
+			},
+		},
+	}
+
+	t.Run("UnmarshalFromMap", func(t *testing.T) {
+		var cdMap map[string]any
+		if err = json.Unmarshal(cdBytes, &cdMap); err != nil {
+			t.Fatal(err)
+		}
+
+		cgrEvWithIDs.Event[utils.CostDetails] = cdMap
+
+		cgrEvBytes, err := json.Marshal(cgrEvWithIDs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var rcvCGREv CGREventWithEeIDs
+		if err = json.Unmarshal(cgrEvBytes, &rcvCGREv); err != nil {
+			t.Fatal(err)
+		}
+
+		expectedType := "*engine.EventCost"
+		if cdType := fmt.Sprintf("%T", rcvCGREv.Event[utils.CostDetails]); cdType != expectedType {
+			t.Fatalf("expected type to be %v, received %v", expectedType, cdType)
+		}
+
+		cgrEvWithIDs.Event[utils.CostDetails] = testEC
+		if !reflect.DeepEqual(rcvCGREv, cgrEvWithIDs) {
+			t.Errorf("expected: %v,\nreceived: %v",
+				utils.ToJSON(cgrEvWithIDs), utils.ToJSON(rcvCGREv))
+		}
+	})
+	t.Run("UnmarshalFromString", func(t *testing.T) {
+		cdStringBytes, err := json.Marshal(string(cdBytes))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var cdString string
+		if err = json.Unmarshal(cdStringBytes, &cdString); err != nil {
+			t.Fatal(err)
+		}
+
+		cgrEvWithIDs.Event[utils.CostDetails] = cdString
+
+		cgrEvBytes, err := json.Marshal(cgrEvWithIDs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var rcvCGREv CGREventWithEeIDs
+		if err = json.Unmarshal(cgrEvBytes, &rcvCGREv); err != nil {
+			t.Fatal(err)
+		}
+
+		expectedType := "*engine.EventCost"
+		if cdType := fmt.Sprintf("%T", rcvCGREv.Event[utils.CostDetails]); cdType != expectedType {
+			t.Fatalf("expected type to be %v, received %v", expectedType, cdType)
+		}
+
+		cgrEvWithIDs.Event[utils.CostDetails] = testEC
+		if !reflect.DeepEqual(rcvCGREv, cgrEvWithIDs) {
+			t.Errorf("expected: %v,\nreceived: %v",
+				utils.ToJSON(cgrEvWithIDs), utils.ToJSON(rcvCGREv))
+		}
+	})
+}


### PR DESCRIPTION
Incomplete, needs to be discussed

From the commit message:
 
> Note: UnmarshalJSON method is still required for CGREventWithEeIDs
> because it embeds CGREvent and it automatically uses its UnmarshalJSON
> method.

This applies to every struct that embeds CGREvent. The only solution I can think of right now is implementing a custom Unmarshal method for all these types, but there might be better solutions. 
