### PR TITLE
Ensure EC FieldAsInterface method works correctly

### DIFF
--- a/engine/actions_test.go
+++ b/engine/actions_test.go
@@ -85,9 +85,9 @@ func TestActionPlanOnlyHour(t *testing.T) {
 }
 
 func TestActionPlanHourYear(t *testing.T) {
-	at := &ActionTiming{Timing: &RateInterval{Timing: &RITiming{Years: utils.Years{2024}, StartTime: "10:01:00"}}}
+	at := &ActionTiming{Timing: &RateInterval{Timing: &RITiming{Years: utils.Years{2029}, StartTime: "10:01:00"}}}
 	st := at.GetNextStartTime(referenceDate)
-	expected := time.Date(2024, 1, 1, 10, 1, 0, 0, time.Local)
+	expected := time.Date(2029, 1, 1, 10, 1, 0, 0, time.Local)
 	if !st.Equal(expected) {
 		t.Errorf("Expected %v was %v", expected, st)
 	}

--- a/engine/eventcost.go
+++ b/engine/eventcost.go
@@ -1032,7 +1032,7 @@ func (ec *EventCost) getChargesForPath(fldPath []string, chr *ChargingInterval) 
 	if fldPath[1] == utils.Accounting {
 		return ec.getAcountingForPath(fldPath[2:], ec.Accounting[incr.AccountingID])
 	}
-	return incr.FieldAsInterface(fldPath)
+	return incr.FieldAsInterface(fldPath[1:])
 }
 
 func (ec *EventCost) getRatingForPath(fldPath []string, rating *RatingUnit) (val any, err error) {
@@ -1046,9 +1046,13 @@ func (ec *EventCost) getRatingForPath(fldPath []string, rating *RatingUnit) (val
 	switch fldPath[0] {
 	default:
 		opath, indx := utils.GetPathIndex(fldPath[0])
+
+		// Break the switch and leave the validation to
+		// the RatingUnit's FieldAsInterface method.
 		if opath != utils.Rates {
-			return nil, fmt.Errorf("unsupported field prefix: <%s>", opath)
+			break
 		}
+
 		rts, has := ec.Rates[rating.RatesID]
 		if !has || rts == nil {
 			return nil, utils.ErrNotFound
@@ -1102,7 +1106,8 @@ func (ec *EventCost) getAcountingForPath(fldPath []string, bc *BalanceCharge) (v
 		return bc, nil
 	}
 
-	if fldPath[0] == utils.Balance {
+	switch fldPath[0] {
+	case utils.Balance:
 		bl := ec.AccountSummary.BalanceSummaries.BalanceSummaryWithUUD(bc.BalanceUUID)
 		if bl == nil {
 			return nil, utils.ErrNotFound
@@ -1111,7 +1116,10 @@ func (ec *EventCost) getAcountingForPath(fldPath []string, bc *BalanceCharge) (v
 			return bl, nil
 		}
 		return bl.FieldAsInterface(fldPath[1:])
-
+	case utils.Rating:
+		return ec.getRatingForPath(fldPath[1:], ec.Rating[bc.RatingID])
+	case utils.ExtraCharge:
+		return ec.getAcountingForPath(fldPath[1:], ec.Accounting[bc.ExtraChargeID])
 	}
 	return bc.FieldAsInterface(fldPath)
 }

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -504,6 +504,7 @@ const (
 	RatingFilter                = "RatingFilter"
 	Accounting                  = "Accounting"
 	Rating                      = "Rating"
+	ExtraCharge                 = "ExtraCharge"
 	Charges                     = "Charges"
 	CompressFactor              = "CompressFactor"
 	Increments                  = "Increments"


### PR DESCRIPTION
- trim fldPath Increments before retrieving the field
- Rating map can be accessed from Accounting
- ExtraCharges can be accessed from Accounting
- RatingUnit fields that did not represent the id of another EC struct are now retrievable
- add unit tests