### PR TITLE
Revise docker ansible script

### DIFF
--- a/data/ansible/docker/docker.yaml
+++ b/data/ansible/docker/docker.yaml
@@ -37,9 +37,6 @@
     enabled: yes
     masked: no
 
-- name: Install Docker Module for Python
-  shell: "pip3 install docker"
-
 - name: Creates directory
   become: yes
   file:

--- a/data/ansible/docker/main.yaml
+++ b/data/ansible/docker/main.yaml
@@ -57,7 +57,7 @@
       register: nginxConfig
 
     - name: Configure NGINX server
-      include: nginx.yaml
+      include_tasks: nginx.yaml
       when: nginxConfig.stdout_lines|length < 1 or users_filename|length > 0
 
     - name: Enable and start nginx
@@ -68,7 +68,7 @@
         enabled: yes
       
     - name: Configure docker 
-      include: docker.yaml
+      import_tasks: docker.yaml
 
 ###########################################################################################################################
 ###########################################################################################################################


### PR DESCRIPTION
- use include/import_tasks instead of the deprecated include.

Used include_tasks for nginx tasks because they might cause problems due to depending on the nginxConfig variable inside the conditional statements.
Used import_tasks for docker tasks since they seem like they can be safely pre-processed.

- remove task installing docker module for python