### PR TITLE
Don't recursively change ownership of package directories.

### DIFF
--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -10,9 +10,6 @@ package-contains-documentation-outside-usr-share-doc [usr/share/cgrates/*]
 # Only systemd is supported
 package-supports-alternative-init-but-no-init.d-script [lib/systemd/system/cgrates.service]
 
-# No good alternative
-recursive-privilege-change "chown -R" [postinst:*]
-
 # Sources for dependencies are included as-is
 spelling-error-in-binary *
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -28,9 +28,18 @@ case "$1" in
 
 	configure)
 		adduser --quiet --system --group --disabled-password --shell /bin/false --home /run/cgrates --gecos "CGRateS" cgrates || true
-		chown -R cgrates:cgrates /var/spool/cgrates/
-		chown -R cgrates:cgrates /var/lib/cgrates/
-		chown -R cgrates:cgrates /usr/share/cgrates/
+		chown cgrates:cgrates /var/lib/cgrates/
+		chown cgrates:cgrates /var/lib/cgrates/cache_dump/
+		chown cgrates:cgrates /var/spool/cgrates/
+		chown cgrates:cgrates /var/spool/cgrates/analyzers/
+		chown cgrates:cgrates /var/spool/cgrates/cdre/
+		chown cgrates:cgrates /var/spool/cgrates/cdre/csv/
+		chown cgrates:cgrates /var/spool/cgrates/cdre/fwv/
+		chown cgrates:cgrates /var/spool/cgrates/ers/
+		chown cgrates:cgrates /var/spool/cgrates/ers/in/
+		chown cgrates:cgrates /var/spool/cgrates/ers/out/
+		chown cgrates:cgrates /var/spool/cgrates/failed_posts/
+		chown cgrates:cgrates /var/spool/cgrates/tpe/
 		chown root:adm /var/log/cgrates
 		chmod 775 /var/log/cgrates
         ;;


### PR DESCRIPTION
The Debian package maintainer script should not recursively change the ownership on the package directories.

The /var/spool/cgrates on our systems is very large, which causes this operation to take a very long time, making package upgrades a PITA because the cgrates service becomes unresponsive to the cluster resource manager.

The ownership of /usr/share/cgrates shouldn't be changed at all, because /usr can be mounted read-only, cgrates should not be writing to that directory tree.

Instead of using `chown -R` the directories created by the package are acted on individually.

Note: This change need to be applied to the 1.0 and v0.10 branches too.