### PR TITLE
Optimize removeFilterIndexesForFilter function + tests

### DIFF
--- a/engine/libindex_test.go
+++ b/engine/libindex_test.go
@@ -1,0 +1,242 @@
+/*
+Real-time Online/Offline Charging System (OCS) for Telecom & ISP environments
+Copyright (C) ITsysCOM GmbH
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+package engine
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cgrates/cgrates/config"
+	"github.com/cgrates/cgrates/utils"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestLibIndexRemoveFilterIndexesForFilter(t *testing.T) {
+	cfg, err := config.NewDefaultCGRConfig()
+	if err != nil {
+		t.Fatalf("failed to init default cfg: %v", err)
+	}
+	dataDB := NewInternalDB(nil, nil, true, cfg.DataDbCfg().Items)
+	dm := NewDataManager(dataDB, cfg.CacheCfg(), nil)
+	tntCtx := "cgrates.org:*sessions"
+
+	tests := []struct {
+		name    string
+		idx     map[string]utils.StringMap // initial indexes map
+		keys    []string                   // that will be removed from the index
+		itemIDs utils.StringMap
+		want    map[string]utils.StringMap // indexes map after remove
+	}{
+		{
+			name: "remove one filter index from all profiles",
+			idx: map[string]utils.StringMap{
+				"*string:~*req.Account:1001": {
+					"AP1": true,
+					"AP2": true,
+				},
+				"*string:~*req.Account:1002": {
+					"AP1": true,
+					"AP2": true,
+				},
+			},
+			keys: []string{"*string:~*req.Account:1001"},
+			itemIDs: utils.StringMap{
+				"AP1": true,
+				"AP2": true,
+			},
+			want: map[string]utils.StringMap{
+				"*string:~*req.Account:1002": {
+					"AP1": true,
+					"AP2": true,
+				},
+			},
+		},
+		{
+			name: "remove one filter index from one profile",
+			idx: map[string]utils.StringMap{
+				"*string:~*req.Account:1001": {
+					"AP1": true,
+					"AP2": true,
+				},
+				"*string:~*req.Account:1002": {
+					"AP1": true,
+					"AP2": true,
+				},
+			},
+			keys: []string{"*string:~*req.Account:1001"},
+			itemIDs: utils.StringMap{
+				"AP1": true,
+			},
+			want: map[string]utils.StringMap{
+				"*string:~*req.Account:1001": {
+					"AP2": true,
+				},
+				"*string:~*req.Account:1002": {
+					"AP1": true,
+					"AP2": true,
+				},
+			},
+		},
+		{
+			name: "attempt remove non-existent filter index",
+			idx: map[string]utils.StringMap{
+				"*string:~*req.Account:1001": {
+					"AP1": true,
+					"AP2": true,
+				},
+				"*string:~*req.Account:1002": {
+					"AP1": true,
+					"AP2": true,
+				},
+			},
+			keys: []string{"*string:~*req.Account:notfound"},
+			itemIDs: utils.StringMap{
+				"AP1": true,
+				"AP2": true,
+			},
+			want: map[string]utils.StringMap{
+				"*string:~*req.Account:1001": {
+					"AP1": true,
+					"AP2": true,
+				},
+				"*string:~*req.Account:1002": {
+					"AP1": true,
+					"AP2": true,
+				},
+			},
+		},
+		{
+			name: "remove all filter indexes from one profile",
+			idx: map[string]utils.StringMap{
+				"*string:~*req.Account:1001": {
+					"AP1": true,
+					"AP2": true,
+				},
+				"*string:~*req.Account:1002": {
+					"AP1": true,
+					"AP2": true,
+				},
+			},
+			keys: []string{"*string:~*req.Account:1001", "*string:~*req.Account:1002"},
+			itemIDs: utils.StringMap{
+				"AP1": true,
+			},
+			want: map[string]utils.StringMap{
+				"*string:~*req.Account:1001": {
+					"AP2": true,
+				},
+				"*string:~*req.Account:1002": {
+					"AP2": true,
+				},
+			},
+		},
+		{
+			name: "remove all filter indexes from all profiles",
+			idx: map[string]utils.StringMap{
+				"*string:~*req.Account:1001": {
+					"AP1": true,
+					"AP2": true,
+				},
+				"*string:~*req.Account:1002": {
+					"AP1": true,
+					"AP2": true,
+				},
+			},
+			keys: []string{"*string:~*req.Account:1001", "*string:~*req.Account:1002"},
+			itemIDs: utils.StringMap{
+				"AP1": true,
+				"AP2": true,
+			},
+			want: nil,
+		},
+		{
+			name: "remove multiple filter indexes from mixed profiles",
+			idx: map[string]utils.StringMap{
+				"*string:~*req.Account:1001": {
+					"AP1": true,
+					"AP2": true,
+					"AP3": true,
+				},
+				"*string:~*req.Destination:1010": {
+					"AP2": true,
+					"AP3": true,
+				},
+				"*string:~*req.Destination:1011": {
+					"AP1": true,
+					"AP3": true,
+					"AP4": true,
+				},
+				"*string:~*req.Destination:1012": {
+					"AP2": true,
+				},
+			},
+			keys: []string{"*string:~*req.Destination:1010", "*string:~*req.Destination:1012"},
+			itemIDs: utils.StringMap{
+				"AP2": true,
+				"AP3": true,
+			},
+			want: map[string]utils.StringMap{
+				"*string:~*req.Account:1001": {
+					"AP1": true,
+					"AP2": true,
+					"AP3": true,
+				},
+				"*string:~*req.Destination:1011": {
+					"AP1": true,
+					"AP3": true,
+					"AP4": true,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				if err := dataDB.Flush(""); err != nil {
+					t.Logf("failed to flush dataDB: %v", err)
+				}
+			})
+			if err := dm.SetFilterIndexes(utils.CacheAttributeFilterIndexes, tntCtx, test.idx, true, ""); err != nil {
+				t.Fatalf("dm.SetFilterIndexes() returned unexpected error: %v", err)
+			}
+			if err := removeFilterIndexesForFilter(dm, utils.CacheAttributeFilterIndexes, utils.CacheAttributeProfiles,
+				tntCtx, test.keys, test.itemIDs); err != nil {
+				t.Fatalf("removeFilterIndexesForFilter() returned unexpected error: %v", err)
+			}
+			got, err := dm.GetFilterIndexes(utils.CacheAttributeFilterIndexes, tntCtx, "", nil)
+			switch len(test.want) {
+			case 0:
+				if !errors.Is(err, utils.ErrNotFound) {
+					t.Fatalf("dm.GetFilterIndexes(%q,%q) err = %v, want %v",
+						utils.CacheAttributeFilterIndexes, tntCtx, err, utils.ErrNotFound)
+				}
+			default:
+				if err != nil {
+					t.Fatalf("dm.GetFilterIndexes(%q,%q) returned unexpected error: %v",
+						utils.CacheAttributeFilterIndexes, tntCtx, err)
+				}
+			}
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("dm.GetFilterIndexes(%q,%q) returned unexpected indexes (-want +got): \n%s",
+					utils.CacheAttributeFilterIndexes, tntCtx, diff)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/fiorix/go-diameter v3.0.3-0.20190716165154-f4823472d0e0+incompatible
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-sql-driver/mysql v1.7.1
+	github.com/google/go-cmp v0.6.0
 	github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75
 	github.com/jinzhu/gorm v1.9.16
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -90,8 +90,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
Previously made two trips (get and set) for each group of items from an index key being removed. Now, we fetch indexes once at the beginning and store the updated indexes once at the end.

Related to #4357