### PR TITLE
Revise test for ReplayFailedPosts API

### DIFF
--- a/general_tests/ees_it_test.go
+++ b/general_tests/ees_it_test.go
@@ -349,7 +349,7 @@ func TestEEsReplayFailedPosts(t *testing.T) {
 
 "general": {
 	"log_level": 7,
-	"failed_posts_ttl": "3ms",
+	"failed_posts_ttl": "1ms",
 	"poster_attempts": 1
 },
 
@@ -474,11 +474,9 @@ func TestEEsReplayFailedPosts(t *testing.T) {
 		}
 
 		time.Sleep(5 * time.Millisecond)
-		replayFailedDir := t.TempDir()
 		var replayReply string
 		if err := client.Call(context.Background(), utils.APIerSv1ReplayFailedPosts, v1.ReplayFailedPostsParams{
 			SourcePath: failedDir,
-			FailedPath: replayFailedDir,
 			Modules:    []string{"test", "EEs"},
 		}, &replayReply); err != nil {
 			t.Errorf("APIerSv1.ReplayFailedPosts returned unexpected err: %v", err)
@@ -504,8 +502,7 @@ func TestEEsReplayFailedPosts(t *testing.T) {
 		}
 
 		if err := client.Call(context.Background(), utils.APIerSv1ReplayFailedPosts, v1.ReplayFailedPostsParams{
-			SourcePath: replayFailedDir,
-			FailedPath: utils.MetaNone,
+			SourcePath: failedDir,
 			Modules:    []string{"test", "EEs"},
 		}, &replayReply); err != nil {
 			t.Errorf("APIerSv1.ReplayFailedPosts returned unexpected err: %v", err)


### PR DESCRIPTION
- shortened the failed post cache ttl to 1ms to simulate with more than one events file
- use the default FailedPath (which is the same as SourcePath) to check whether writing events that failed to be replayed to the same path would cause an infinite loop.