### PR TITLE
Add reference value functionality to *transfer_balance action

### DIFF
--- a/apier/v1/accounts.go
+++ b/apier/v1/accounts.go
@@ -714,7 +714,7 @@ func (apierSv1 *APIerSv1) RemoveBalances(ctx *context.Context, attr *utils.AttrS
 }
 
 // TransferBalance initiates a balance transfer between accounts, immediately executing the configured actions.
-func (apierSv1 *APIerSv1) TransferBalance(ctx *context.Context, attr utils.AttrTransferBalance, reply *string) (err error) {
+func (apierSv1 *APIerSv1) TransferBalance(ctx *context.Context, attr utils.AttrTransferBalance, reply *string) error {
 
 	// Check for missing mandatory fields in the request attributes.
 	if missing := utils.MissingStructFields(&attr, []string{
@@ -729,12 +729,18 @@ func (apierSv1 *APIerSv1) TransferBalance(ctx *context.Context, attr utils.AttrT
 		attr.Tenant = apierSv1.Config.GeneralCfg().DefaultTenant
 	}
 
-	// Marshal extra parameters including the destination account and balance ID.
-	var extraParams []byte
-	extraParams, err = json.Marshal(map[string]string{
-		utils.DestinationAccountID: attr.Tenant + ":" + attr.DestinationAccountID,
-		utils.DestinationBalanceID: attr.DestinationBalanceID,
-	})
+	// Marshal extra parameters including the destination account, balance ID,
+	// and optional reference value.
+	tmp := struct {
+		DestinationAccountID      string
+		DestinationBalanceID      string
+		DestinationReferenceValue *float64
+	}{
+		DestinationAccountID:      attr.Tenant + ":" + attr.DestinationAccountID,
+		DestinationBalanceID:      attr.DestinationBalanceID,
+		DestinationReferenceValue: attr.DestinationReferenceValue,
+	}
+	extraParams, err := json.Marshal(tmp)
 	if err != nil {
 		return utils.NewErrServerError(err)
 	}

--- a/utils/apitpdata.go
+++ b/utils/apitpdata.go
@@ -880,14 +880,15 @@ type AttrBalance struct {
 }
 
 type AttrTransferBalance struct {
-	Tenant               string
-	SourceAccountID      string
-	SourceBalanceID      string
-	DestinationAccountID string
-	DestinationBalanceID string
-	Units                float64
-	Cdrlog               bool
-	APIOpts              map[string]any
+	Tenant                    string
+	SourceAccountID           string
+	SourceBalanceID           string
+	DestinationAccountID      string
+	DestinationBalanceID      string
+	DestinationReferenceValue *float64
+	Units                     float64
+	Cdrlog                    bool
+	APIOpts                   map[string]any
 }
 
 // TPResourceProfile is used in APIs to manage remotely offline ResourceProfile


### PR DESCRIPTION
The *transfer_balance action can now use a reference value to ensure the destination balance reaches a specified amount. If the destination balance exceeds the reference value, the excess is transferred back to the source balance. If the destination balance is below the reference value, the required amount is transferred from the source balance to the destination balance to reach the specified reference value. An error is returned if the transfer cannot achieve the specified reference value.

Used by specifying DestinationReferenceValue inside ExtraParameters.

Other *transfer_balance changes:
- used json tags when unmarshaling ExtraParameters in order to be able to shorten the names of the fields
- lock the destination account only if it's different from the source account. It is still passed to the Guard function but without a lock key and with 0 timeout.
- if the transfer happens within the same account, update the account and execute its ActionTriggers only once.
- moved transfer units validation after retrieving/creating the destination balance

*cdrlog action has been updated to create cdrs for reference *transfer_balance actions, although improvements are needed and the functionality is not completely tested.

APIerSv1.TransferBalance has been updated to take into account the ReferenceValue parameter.

Added new *transfer_balance action unit tests to account for the new changes.

Added integration tests (incomplete for now, but functionality has been tested manually).