### PR TITLE
Ensure config path stands out when using print_config flag

### DIFF
--- a/cmd/cgr-engine/cgr-engine.go
+++ b/cmd/cgr-engine/cgr-engine.go
@@ -433,7 +433,7 @@ func main() {
 
 	if *printConfig {
 		cfgJSON := utils.ToIJSON(cfg.AsMapInterface(cfg.GeneralCfg().RSRSep))
-		utils.Logger.Info(fmt.Sprintf("Configuration loaded from %s:\n%s", *cfgPath, cfgJSON))
+		utils.Logger.Info(fmt.Sprintf("Configuration loaded from %q:\n%s", *cfgPath, cfgJSON))
 	}
 
 	// init the concurrentRequests


### PR DESCRIPTION
Done by using the %q fmt verb instead of %s, which wraps the path within quotes.