### PR TITLE
Don't trim single digit values when parsing cron

### DIFF
--- a/engine/rateinterval.go
+++ b/engine/rateinterval.go
@@ -68,14 +68,14 @@ func (rit *RITiming) CronString() string {
 		} else {
 			hour, min, sec = "*", "*", "*"
 		}
-		if strings.HasPrefix(hour, "0") {
-			hour = hour[1:]
+		if len(hour) > 1 {
+			hour = strings.TrimPrefix(hour, "0")
 		}
-		if strings.HasPrefix(min, "0") {
-			min = min[1:]
+		if len(min) > 1 {
+			min = strings.TrimPrefix(min, "0")
 		}
-		if strings.HasPrefix(sec, "0") {
-			sec = sec[1:]
+		if len(sec) > 1 {
+			sec = strings.TrimPrefix(sec, "0")
 		}
 	}
 	if len(rit.MonthDays) == 0 {


### PR DESCRIPTION
Fixes an issue where 0 values would become empty inside the cron expressions.

Added unit tests for the edge cases and grouped them together with the previous ones under the same table test.