### PR TITLE
Add precache support for exporters

### DIFF
--- a/services/ees_test.go
+++ b/services/ees_test.go
@@ -54,9 +54,7 @@ func TestEventExporterSCoverage(t *testing.T) {
 		intConnChan: make(chan birpc.ClientConnector, 1),
 		anz:         anz,
 		srvDep:      srvDep,
-		rldChan:     make(chan struct{}, 1),
 		eeS:         &ees.EventExporterS{},
-		stopChan:    make(chan struct{}, 1),
 	}
 	if !srv2.IsRunning() {
 		t.Errorf("Expected service to be running")


### PR DESCRIPTION
Additional changes:
- removed unnecessary locking when initializing the exporter cache map, as the service itself is responsible for locking.
- separated setupCache method into ClearExporterCache and SetupExporterCache methods.
- removed idle ListenAndServe function that was only waiting for the stopChan to close. The reload case was unreachable due to the reload channel being created in Start instead of being passed down.
- removed Shutdown method on EventExporterS and replaced it with the exported ClearExporterCache method as it provided the same functionality.