### PR TITLE
Sync (and update) go version 

### DIFF
--- a/data/ansible/deb_packages/gpg.yaml
+++ b/data/ansible/deb_packages/gpg.yaml
@@ -29,7 +29,7 @@
   shell: 'printf "expire\n{{ gpg_expire }}\nsave\n" | gpg --batch --command-fd 0 --status-fd=2 --edit-key {{ gpg_realname }}'
   when: gpgkeys.stdout_lines|length > 0 and gpgExpKeys.stdout_lines|length > 0
 
-- include: gpg-gen-key.yaml
+- include_tasks: gpg-gen-key.yaml
   when: gpgkeys.stdout_lines|length < 1
 
 - name: get user armored public key

--- a/data/ansible/deb_packages/main.yaml
+++ b/data/ansible/deb_packages/main.yaml
@@ -43,10 +43,10 @@
       apt: name={{ dependencies }} state=present
 
     - name: Configure reprepro
-      include: reprepro.yaml
+      import_tasks: reprepro.yaml
 
     - name: Generate GPG Key
-      include: gpg.yaml
+      import_tasks: gpg.yaml
 
     - name: Check if NGINX needs to be configured
       become: true
@@ -55,7 +55,7 @@
       register: nginxConfig
 
     - name: Configure NGINX server
-      include: nginx.yaml
+      include_tasks: nginx.yaml
       when: nginxConfig.stdout_lines|length < 1
 
     - name: Enable and start nginx

--- a/data/ansible/roles/go/defaults/main.yaml
+++ b/data/ansible/roles/go/defaults/main.yaml
@@ -1,8 +1,8 @@
 ---
-go_version: 1.22.3
+go_version: 1.22.5
 go_platform: linux
 go_arch: amd64
 go_tarball: go{{ go_version }}.{{ go_platform }}-{{ go_arch }}.tar.gz
 go_download_url: https://dl.google.com/go/{{ go_tarball }}
-go_checksum: 8920ea521bad8f6b7bc377b4824982e011c19af27df88a815e3586ea895f1b36
+go_checksum: 904b924d435eaea086515bc63235b192ea441bd8c9b198c507e85009e6e4c7f0
 install_go: true

--- a/data/docker/integration/Dockerfile
+++ b/data/docker/integration/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get clean && \
 RUN touch /logs/mariadb.log /logs/mariadb_script.log /logs/rabbitmq.log 
 RUN chmod 777  /logs/mariadb.log /logs/mariadb_script.log /logs/rabbitmq.log
 
-RUN wget -O go.tgz "https://storage.googleapis.com/golang/go1.22.3.linux-amd64.tar.gz" --progress=dot:giga
+RUN wget -O go.tgz "https://storage.googleapis.com/golang/go1.22.5.linux-amd64.tar.gz" --progress=dot:giga
 RUN tar -C /usr/local -xzf go.tgz
 RUN rm go.tgz
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -145,8 +145,8 @@ To install the latest Go version at the time of writing this documentation, run:
    # sudo dnf install -y wget tar for .rpm distros
    sudo rm -rf /usr/local/go
    cd /tmp
-   wget https://go.dev/dl/go1.22.3.linux-amd64.tar.gz
-   sudo tar -C /usr/local -xzf go1.22.3.linux-amd64.tar.gz
+   wget https://go.dev/dl/go1.22.5.linux-amd64.tar.gz
+   sudo tar -C /usr/local -xzf go1.22.5.linux-amd64.tar.gz
    export PATH=$PATH:/usr/local/go/bin
 
 Installation:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cgrates/cgrates
 
-go 1.22.4
+go 1.22.5
 
 // replace github.com/cgrates/radigo => ../radigo
 

--- a/packages/copr.fedorainfracloud.org/cgrates.spec
+++ b/packages/copr.fedorainfracloud.org/cgrates.spec
@@ -1,6 +1,6 @@
 # Define global variables
 %global version 0.11.0~dev
-%global go_version 1.22.3
+%global go_version 1.22.5
 
 # Define system paths
 %define debug_package  %{nil}

--- a/packages/redhat_fedora/cgrates.spec
+++ b/packages/redhat_fedora/cgrates.spec
@@ -1,6 +1,6 @@
 # Define global variables
 %global version 0.11.0~dev
-%global go_version 1.22.3
+%global go_version 1.22.5
 %global git_commit %(echo $gitLastCommit)
 %global releaseTag %(echo $rpmTag)
 


### PR DESCRIPTION
go.mod had a later version than the one used inside the
role, which caused the deb packaging to fail.
