### PR TITLE
Ensure refund flag is not ignored when rerate is true

### DIFF
--- a/engine/storage_interface.go
+++ b/engine/storage_interface.go
@@ -314,8 +314,5 @@ func (gm *GOBMarshaler) Unmarshal(data []byte, v any) error {
 
 // Decide the value of cacheCommit parameter based on transactionID
 func cacheCommit(transactionID string) bool {
-	if transactionID == utils.NonTransactional {
-		return true
-	}
-	return false
+	return transactionID == utils.NonTransactional
 }


### PR DESCRIPTION
By default setting rerate to true also sets refund to true, but flags should take precedence over defaults.

If rerate is true and refund is false, remove any previous CostDetails from event to force rerate.

Centralize the parsing of processing flags.