### PR TITLE
Remove CGRConfig and error global variables used in tests

### DIFF
--- a/config/analyzerscfg_test.go
+++ b/config/analyzerscfg_test.go
@@ -37,7 +37,7 @@ func TestAnalyzerSCfgloadFromJsonCfg(t *testing.T) {
 		TTL:             24 * time.Hour,
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.analyzerSCfg.loadFromJSONCfg(jsonCfg); err != nil {
+	if err := jsnCfg.analyzerSCfg.loadFromJSONCfg(jsonCfg); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(jsnCfg.analyzerSCfg, expected) {
 		t.Errorf("Expected %+v \n, received %+v", expected, jsnCfg.analyzerSCfg)
@@ -89,14 +89,14 @@ func TestAnalyzerSCfgloadFromJsonCfgErr(t *testing.T) {
 		Cleanup_interval: utils.StringPointer("24ha"),
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.analyzerSCfg.loadFromJSONCfg(jsonCfg); err == nil {
+	if err := jsnCfg.analyzerSCfg.loadFromJSONCfg(jsonCfg); err == nil {
 		t.Errorf("Expected error received nil")
 	}
 	jsonCfg = &AnalyzerSJsonCfg{
 		Ttl: utils.StringPointer("24ha"),
 	}
 	jsnCfg = NewDefaultCGRConfig()
-	if err = jsnCfg.analyzerSCfg.loadFromJSONCfg(jsonCfg); err == nil {
+	if err := jsnCfg.analyzerSCfg.loadFromJSONCfg(jsonCfg); err == nil {
 		t.Errorf("Expected error received nil")
 	}
 }

--- a/config/apiercfg_test.go
+++ b/config/apiercfg_test.go
@@ -40,7 +40,7 @@ func TestApierCfgloadFromJsonCfg(t *testing.T) {
 		EEsConns:        []string{utils.ConcatenatedKey(utils.MetaInternal, utils.MetaEEs), "*conn1"},
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.apier.loadFromJSONCfg(jsonCfg); err != nil {
+	if err := jsnCfg.apier.loadFromJSONCfg(jsonCfg); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.apier) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.apier))

--- a/config/attributescfg_test.go
+++ b/config/attributescfg_test.go
@@ -60,7 +60,7 @@ func TestAttributeSCfgloadFromJsonCfg(t *testing.T) {
 		},
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.attributeSCfg.loadFromJSONCfg(jsonCfg); err != nil {
+	if err := jsnCfg.attributeSCfg.loadFromJSONCfg(jsonCfg); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.attributeSCfg) {
 		t.Errorf("Expected %+v, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.attributeSCfg))

--- a/config/cachecfg_test.go
+++ b/config/cachecfg_test.go
@@ -70,9 +70,9 @@ func TestCacheCfgloadFromJsonCfg(t *testing.T) {
 		ReplicationConns: []string{"conn1", "conn2"},
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.cacheCfg.loadFromJSONCfg(nil); err != nil {
+	if err := jsnCfg.cacheCfg.loadFromJSONCfg(nil); err != nil {
 		t.Error(err)
-	} else if err = jsnCfg.cacheCfg.loadFromJSONCfg(jsonCfg); err != nil {
+	} else if err := jsnCfg.cacheCfg.loadFromJSONCfg(jsonCfg); err != nil {
 		t.Error(err)
 	} else {
 		if !reflect.DeepEqual(expected.Partitions[utils.MetaDestinations], jsnCfg.cacheCfg.Partitions[utils.MetaDestinations]) {
@@ -90,7 +90,7 @@ func TestReplicationConnsLoadFromJsonCfg(t *testing.T) {
 	}
 	expErrMessage := "replication connection ID needs to be different than *internal"
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.cacheCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expErrMessage {
+	if err := jsnCfg.cacheCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expErrMessage {
 		t.Errorf("Expected %+v , recevied %+v", expErrMessage, err)
 	}
 }
@@ -128,7 +128,7 @@ func TestCacheParamCfgloadFromJsonCfg2(t *testing.T) {
 	}
 	expErrMessage := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.cacheCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expErrMessage {
+	if err := jsnCfg.cacheCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expErrMessage {
 		t.Errorf("Expected %+v \n, recevied %+v", expErrMessage, err)
 	}
 }
@@ -147,7 +147,7 @@ func TestAddTmpCaches(t *testing.T) {
 	}
 	expected.AddTmpCaches()
 	json := NewDefaultCGRConfig()
-	if err = json.cacheCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := json.cacheCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected.Partitions[utils.CacheRatingProfilesTmp],
 		json.cacheCfg.Partitions[utils.CacheRatingProfilesTmp]) {

--- a/config/cdrscfg_test.go
+++ b/config/cdrscfg_test.go
@@ -53,7 +53,7 @@ func TestCdrsCfgloadFromJsonCfg(t *testing.T) {
 		ExtraFields:      RSRParsers{},
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.cdrsCfg.loadFromJSONCfg(jsonCfg); err != nil {
+	if err := jsnCfg.cdrsCfg.loadFromJSONCfg(jsonCfg); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.cdrsCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.cdrsCfg))
@@ -66,7 +66,7 @@ func TestExtraFieldsinloadFromJsonCfg(t *testing.T) {
 	}
 	expectedErrMessage := "emtpy RSRParser in rule: <>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.cdrsCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expectedErrMessage {
+	if err := jsonCfg.cdrsCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expectedErrMessage {
 		t.Errorf("Expected %+v, received %+v", expectedErrMessage, err)
 	}
 }

--- a/config/chargerscfg_test.go
+++ b/config/chargerscfg_test.go
@@ -44,7 +44,7 @@ func TestChargerSCfgloadFromJsonCfg(t *testing.T) {
 		NestedFields:        true,
 	}
 	jsncfg := NewDefaultCGRConfig()
-	if err = jsncfg.chargerSCfg.loadFromJSONCfg(jsonCfg); err != nil {
+	if err := jsncfg.chargerSCfg.loadFromJSONCfg(jsonCfg); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsncfg.chargerSCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsncfg.chargerSCfg))

--- a/config/config_it_test.go
+++ b/config/config_it_test.go
@@ -91,18 +91,18 @@ func testNewCgrJsonCfgFromHttp(t *testing.T) {
 	addr := "https://raw.githubusercontent.com/cgrates/cgrates/master/data/conf/samples/tutmongo/cgrates.json"
 	expVal := NewDefaultCGRConfig()
 
-	err = expVal.loadConfigFromPath(path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo"),
+	err := expVal.loadConfigFromPath(path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo"),
 		[]func(*CgrJsonCfg) error{expVal.loadFromJSONCfg}, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err = net.DialTimeout(utils.TCP, addr, time.Second); err != nil { // check if site is up
+	if _, err := net.DialTimeout(utils.TCP, addr, time.Second); err != nil { // check if site is up
 		return
 	}
 
 	rply := NewDefaultCGRConfig()
-	if err = rply.loadConfigFromPath(addr, []func(*CgrJsonCfg) error{rply.loadFromJSONCfg}, false); err != nil {
+	if err := rply.loadConfigFromPath(addr, []func(*CgrJsonCfg) error{rply.loadFromJSONCfg}, false); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expVal, rply) {
 		t.Errorf("Expected: %s ,received: %s", utils.ToJSON(expVal), utils.ToJSON(rply))
@@ -121,7 +121,7 @@ func testNewCGRConfigFromPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err = net.DialTimeout(utils.TCP, addr, time.Second); err != nil { // check if site is up
+	if _, err := net.DialTimeout(utils.TCP, addr, time.Second); err != nil { // check if site is up
 		return
 	}
 
@@ -138,7 +138,7 @@ func testCGRConfigReloadAttributeS(t *testing.T) {
 		cfg.rldChans[section] = make(chan struct{}, 1)
 	}
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: ATTRIBUTE_JSN,
@@ -173,7 +173,7 @@ func testCGRConfigReloadChargerSDryRun(t *testing.T) {
 		cfg.rldChans[section] = make(chan struct{}, 1)
 	}
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: ChargerSCfgJson,
@@ -196,7 +196,7 @@ func testCGRConfigReloadChargerS(t *testing.T) {
 		cfg.rldChans[section] = make(chan struct{}, 1)
 	}
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: ChargerSCfgJson,
@@ -224,7 +224,7 @@ func testCGRConfigReloadThresholdS(t *testing.T) {
 		cfg.rldChans[section] = make(chan struct{}, 1)
 	}
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: THRESHOLDS_JSON,
@@ -254,7 +254,7 @@ func testCGRConfigReloadStatS(t *testing.T) {
 		cfg.rldChans[section] = make(chan struct{}, 1)
 	}
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: STATS_JSON,
@@ -285,7 +285,7 @@ func testCGRConfigReloadResourceS(t *testing.T) {
 		cfg.rldChans[section] = make(chan struct{}, 1)
 	}
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: RESOURCES_JSON,
@@ -317,7 +317,7 @@ func testCGRConfigReloadSupplierS(t *testing.T) {
 		cfg.rldChans[section] = make(chan struct{}, 1)
 	}
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: RouteSJson,
@@ -402,7 +402,7 @@ func testCGRConfigReloadSchedulerS(t *testing.T) {
 		cfg.rldChans[section] = make(chan struct{}, 1)
 	}
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: SCHEDULER_JSN,
@@ -431,7 +431,7 @@ func testCGRConfigReloadCDRs(t *testing.T) {
 	}
 	cfg.RalsCfg().Enabled = true
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: CDRS_JSN,
@@ -470,7 +470,7 @@ func testCGRConfigReloadRALs(t *testing.T) {
 	blMap := cfg.RalsCfg().BalanceRatingSubject
 	maxComp := cfg.RalsCfg().MaxComputedUsage
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: RALS_JSN,
@@ -505,7 +505,7 @@ func testCGRConfigReloadSessionS(t *testing.T) {
 	cfg.ChargerSCfg().Enabled = true
 	cfg.CdrsCfg().Enabled = true
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: SessionSJson,
@@ -565,7 +565,7 @@ func testCGRConfigReloadERs(t *testing.T) {
 	}
 	cfg.SessionSCfg().Enabled = true
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "ers_example"),
 			Section: ERsJson,
@@ -679,7 +679,7 @@ func testCGRConfigReloadDNSAgent(t *testing.T) {
 	}
 	cfg.SessionSCfg().Enabled = true
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "dnsagent_reload"),
 			Section: DNSAgentJson,
@@ -716,7 +716,7 @@ func testCGRConfigReloadFreeswitchAgent(t *testing.T) {
 	}
 	cfg.SessionSCfg().Enabled = true
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "freeswitch_reload"),
 			Section: FreeSWITCHAgentJSN,
@@ -939,7 +939,7 @@ func testCGRConfigReloadConfigFromJSONSessionS(t *testing.T) {
 	cfg.ChargerSCfg().Enabled = true
 	cfg.CdrsCfg().Enabled = true
 	var reply string
-	if err = cfg.V1SetConfig(context.Background(),
+	if err := cfg.V1SetConfig(context.Background(),
 		&SetConfigArgs{
 			Config: map[string]any{
 				"sessions": map[string]any{
@@ -1001,7 +1001,7 @@ func testCGRConfigReloadConfigFromStringSessionS(t *testing.T) {
 	cfg.ChargerSCfg().Enabled = true
 	cfg.CdrsCfg().Enabled = true
 	var reply string
-	if err = cfg.V1SetConfigFromJSON(context.Background(),
+	if err := cfg.V1SetConfigFromJSON(context.Background(),
 		&SetConfigFromJSONArgs{
 			Config: `{
 	"sessions":{
@@ -1071,7 +1071,7 @@ func testCGRConfigReloadAll(t *testing.T) {
 	cfg.ChargerSCfg().Enabled = true
 	cfg.CdrsCfg().Enabled = true
 	var reply string
-	if err = cfg.V1ReloadConfig(context.Background(),
+	if err := cfg.V1ReloadConfig(context.Background(),
 		&ReloadArgs{
 			Path:    path.Join("/usr", "share", "cgrates", "conf", "samples", "tutmongo2"),
 			Section: utils.MetaAll,
@@ -1231,7 +1231,7 @@ func testLoadConfigFromFolderFileNotFound(t *testing.T) {
 	cfg := NewDefaultCGRConfig()
 
 	expected := "file </usr/share/cgrates/conf/samples/docker/cgrates.json>:NOT_FOUND:ENV_VAR:DOCKER_IP"
-	if err = cfg.loadConfigFromFolder("/usr/share/cgrates/conf/samples/",
+	if err := cfg.loadConfigFromFolder("/usr/share/cgrates/conf/samples/",
 		[]func(jsonCfg *CgrJsonCfg) error{cfg.loadFromJSONCfg},
 		false); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
@@ -1240,35 +1240,35 @@ func testLoadConfigFromFolderFileNotFound(t *testing.T) {
 
 func testLoadConfigFromFolderOpenError(t *testing.T) {
 	newDir := "/tmp/testLoadConfigFromFolderOpenError"
-	if err = os.MkdirAll(newDir, 0755); err != nil {
+	if err := os.MkdirAll(newDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	cfg := NewDefaultCGRConfig()
 
 	expected := "open /tmp/testLoadConfigFromFolderOpenError/notes.json: no such file or directory"
-	if err = cfg.loadConfigFromFile(path.Join(newDir, "notes.json"),
+	if err := cfg.loadConfigFromFile(path.Join(newDir, "notes.json"),
 		[]func(jsonCfg *CgrJsonCfg) error{cfg.loadFromJSONCfg},
 		false); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
-	if err = os.RemoveAll(newDir); err != nil {
+	if err := os.RemoveAll(newDir); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func testLoadConfigFromFolderNoConfigFound(t *testing.T) {
 	newDir := "/tmp/[]"
-	if err = os.MkdirAll(newDir, 0755); err != nil {
+	if err := os.MkdirAll(newDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	cfg := NewDefaultCGRConfig()
 
-	if err = cfg.loadConfigFromFolder(newDir,
+	if err := cfg.loadConfigFromFolder(newDir,
 		[]func(jsonCfg *CgrJsonCfg) error{cfg.loadFromJSONCfg},
 		false); err == nil || err != filepath.ErrBadPattern {
 		t.Errorf("Expected %+v, received %+v", filepath.ErrBadPattern, err)
 	}
-	if err = os.RemoveAll(newDir); err != nil {
+	if err := os.RemoveAll(newDir); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1277,7 +1277,7 @@ func testLoadConfigFromPathInvalidArgument(t *testing.T) {
 	cfg := NewDefaultCGRConfig()
 
 	expected := "stat /\x00: invalid argument"
-	if err = cfg.loadConfigFromPath("/\x00",
+	if err := cfg.loadConfigFromPath("/\x00",
 		[]func(jsonCfg *CgrJsonCfg) error{cfg.loadFromJSONCfg},
 		false); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
@@ -1286,36 +1286,36 @@ func testLoadConfigFromPathInvalidArgument(t *testing.T) {
 
 func testLoadConfigFromPathValidPath(t *testing.T) {
 	newDir := "/tmp/testLoadConfigFromPathValidPath"
-	if err = os.MkdirAll(newDir, 0755); err != nil {
+	if err := os.MkdirAll(newDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	cfg := NewDefaultCGRConfig()
 
 	expected := "No config file found on path /tmp/testLoadConfigFromPathValidPath"
-	if err = cfg.loadConfigFromPath(newDir,
+	if err := cfg.loadConfigFromPath(newDir,
 		[]func(jsonCfg *CgrJsonCfg) error{cfg.loadFromJSONCfg},
 		false); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
-	if err = os.RemoveAll(newDir); err != nil {
+	if err := os.RemoveAll(newDir); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func testLoadConfigFromPathFile(t *testing.T) {
 	newDir := "/tmp/testLoadConfigFromPathFile"
-	if err = os.MkdirAll(newDir, 0755); err != nil {
+	if err := os.MkdirAll(newDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	cfg := NewDefaultCGRConfig()
 
 	expected := "No config file found on path /tmp/testLoadConfigFromPathFile"
-	if err = cfg.loadConfigFromPath(newDir,
+	if err := cfg.loadConfigFromPath(newDir,
 		[]func(jsonCfg *CgrJsonCfg) error{cfg.loadFromJSONCfg},
 		false); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
-	if err = os.RemoveAll(newDir); err != nil {
+	if err := os.RemoveAll(newDir); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1349,11 +1349,11 @@ func testHandleConfigSFileErrorWrite(t *testing.T) {
 	w := new(responseTest)
 	handleConfigSFile(path.Join(flPath, "random.json"), w)
 
-	if err = os.Remove(path.Join(flPath, "random.json")); err != nil {
+	if err := os.Remove(path.Join(flPath, "random.json")); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = os.RemoveAll(flPath); err != nil {
+	if err := os.RemoveAll(flPath); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1373,11 +1373,11 @@ func testHandleConfigSFolderErrorWrite(t *testing.T) {
 	w := new(responseTest)
 	handleConfigSFolder(flPath, w)
 
-	if err = os.Remove(path.Join(flPath, "random.json")); err != nil {
+	if err := os.Remove(path.Join(flPath, "random.json")); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = os.RemoveAll(flPath); err != nil {
+	if err := os.RemoveAll(flPath); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,10 +33,9 @@ import (
 )
 
 var cfg *CGRConfig
-var err error
 
 func TestNewDefaultConfigError(t *testing.T) {
-	if _, err = newCGRConfig([]byte(CGRATES_CFG_JSON)); err != nil {
+	if _, err := newCGRConfig([]byte(CGRATES_CFG_JSON)); err != nil {
 		t.Error(err)
 	}
 }
@@ -83,9 +82,6 @@ func TestCgrCfgLoadWithDefaults(t *testing.T) {
 
 }`
 	eCgrCfg := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	eCgrCfg.fsAgentCfg.Enabled = true
 	eCgrCfg.fsAgentCfg.EventSocketConns = []*FsConnCfg{
 		{Address: "1.2.3.4:8021", Password: "ClueCon", Reconnects: 3, ReplyTimeout: 3 * time.Second, Alias: "123"},
@@ -1015,9 +1011,6 @@ func TestLoadRPCConnsError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field RPCConnsJson.PoolSize of type int"
 	cgrCfg := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrJSONCfg, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrCfg.loadRPCConns(cgrJSONCfg); err == nil || err.Error() != expected {
@@ -1038,9 +1031,6 @@ func TestLoadGeneralCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal array into Go struct field GeneralJsonCfg.Node_id of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadGeneralCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1056,9 +1046,6 @@ func TestLoadCacheCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field CacheJsonCfg.Replication_conns of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadCacheCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1074,9 +1061,6 @@ func TestLoadListenCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field ListenJsonCfg.Http_tls of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadListenCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1092,9 +1076,6 @@ func TestLoadHTTPCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field HTTPJsonCfg.Auth_users of type map[string]string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadHTTPCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1110,9 +1091,6 @@ func TestLoadDataDBCfgErrorCase1(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field DbJsonCfg.Db_host of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadDataDBCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1128,9 +1106,6 @@ func TestLoadDataDBCfgErrorCase2(t *testing.T) {
 }`
 	expected := "Remote connection ID needs to be different than *internal"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else {
@@ -1150,9 +1125,6 @@ func TestLoadStorDbCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field DbJsonCfg.Db_port of type int"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadStorDBCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1168,9 +1140,6 @@ func TestLoadFilterSCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field FilterSJsonCfg.Stats_conns of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadFilterSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1186,9 +1155,6 @@ func TestLoadRalSCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field RalsJsonCfg.Stats_conns of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadRalSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1204,9 +1170,6 @@ func TestLoadSchedulerCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field SchedulerJsonCfg.Filters of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadSchedulerCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1222,9 +1185,6 @@ func TestLoadCdrsCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field CdrsJsonCfg.Ees_conns of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadCdrsCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1240,9 +1200,6 @@ func TestLoadSessionSCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field SessionSJsonCfg.Session_ttl_usage of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadSessionSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1258,9 +1215,6 @@ func TestLoadFreeswitchAgentCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field FreeswitchAgentJsonCfg.sessions_conns of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadFreeswitchAgentCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1276,9 +1230,6 @@ func TestLoadKamAgentCfgError(t *testing.T) {
 	}`
 	expected := "json: cannot unmarshal number into Go struct field KamAgentJsonCfg.Timezone of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadKamAgentCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1294,9 +1245,6 @@ func TestLoadAsteriskAgentCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field AsteriskAgentJsonCfg.Sessions_conns of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadAsteriskAgentCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1316,9 +1264,6 @@ func TestLoadDiameterAgentCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field ReqProcessorJsnCfg.Request_processors.ID of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadDiameterAgentCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1338,9 +1283,6 @@ func TestLoadRadiusAgentCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field RadiListenerJsnCfg.listeners.Auth_Address of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadRadiusAgentCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1360,9 +1302,6 @@ func TestLoadDNSAgentCfgError(t *testing.T) {
 	}`
 	expected := "json: cannot unmarshal number into Go struct field DnsListenerJsnCfg.Listeners.Address of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadDNSAgentCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1380,9 +1319,6 @@ func TestLoadHttpAgentCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal array into Go struct field HttpAgentJsonCfg.Id of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadHTTPAgentCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1400,9 +1336,6 @@ func TestLoadAttributeSCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field AttributesOptsJson.Opts.*processRuns of type int"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadAttributeSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1418,9 +1351,6 @@ func TestLoadChargerSCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field ChargerSJsonCfg.Prefix_indexed_fields of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadChargerSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1436,9 +1366,6 @@ func TestLoadResourceSCfgError(t *testing.T) {
 	}`
 	expected := "json: cannot unmarshal string into Go struct field ResourceSJsonCfg.String_indexed_fields of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadResourceSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1454,9 +1381,6 @@ func TestLoadStatSCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field StatServJsonCfg.String_indexed_fields of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadStatSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1472,9 +1396,6 @@ func TestLoadThresholdSCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field ThresholdSJsonCfg.Store_interval of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadThresholdSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1492,9 +1413,6 @@ func TestLoadLoaderSCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field LoaderJsonCfg.Run_delay of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadLoaderSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1510,9 +1428,6 @@ func TestLoadRouteSCfgError(t *testing.T) {
 	}`
 	expected := "json: cannot unmarshal string into Go struct field RouteSJsonCfg.String_indexed_fields of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadRouteSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1528,9 +1443,6 @@ func TestLoadMailerCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field MailerJsonCfg.Server of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadMailerCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1546,9 +1458,6 @@ func TestLoadSureTaxCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field SureTaxJsonCfg.Sales_type_code of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadSureTaxCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1564,9 +1473,6 @@ func TestLoadDispatcherSCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field DispatcherSJsonCfg.Attributes_conns of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadDispatcherSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1584,9 +1490,6 @@ func TestLoadDispatcherHCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field RegistrarCJsonCfg.Dispatchers.Refresh_interval of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadRegistrarCCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1602,9 +1505,6 @@ func TestLoadLoaderCgrCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field LoaderCfgJson.Caches_conns of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadLoaderCgrCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1620,9 +1520,6 @@ func TestLoadMigratorCgrCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field MigratorCfgJson.Users_filters of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadMigratorCgrCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1638,9 +1535,6 @@ func TestLoadTlsCgrCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field TlsJsonCfg.Server_policy of type int"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadTLSCgrCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1657,9 +1551,6 @@ func TestLoadAnalyzerCgrCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field AnalyzerSJsonCfg.Enabled of type bool"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadAnalyzerCgrCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1675,9 +1566,6 @@ func TestLoadAPIBanCgrCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field APIBanJsonCfg.Enabled of type bool"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadAPIBanCgrCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1693,9 +1581,6 @@ func TestLoadApierCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field ApierJsonCfg.Scheduler_conns of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(myJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadApierCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1711,9 +1596,6 @@ func TestLoadErsCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal string into Go struct field ERsJsonCfg.Sessions_conns of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadErsCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1729,9 +1611,6 @@ func TestLoadEesCfgError(t *testing.T) {
     }`
 	expected := "json: cannot unmarshal string into Go struct field EEsJsonCfg.Attributes_conns of type []string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadEesCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1747,9 +1626,6 @@ func TestLoadCoreSCfgError(t *testing.T) {
     }`
 	expected := "json: cannot unmarshal string into Go struct field CoreSJsonCfg.Caps of type int"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadCoreSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1769,9 +1645,6 @@ func TestLoadSIPAgentCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field ReqProcessorJsnCfg.Request_processors.ID of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadSIPAgentCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1791,9 +1664,6 @@ func TestLoadTemplateSCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field FcTemplateJsonCfg.Tag of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadTemplateSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1825,9 +1695,6 @@ func TestLoadConfigsCfgError(t *testing.T) {
 }`
 	expected := "json: cannot unmarshal number into Go struct field ConfigSCfgJson.Url of type string"
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	if cgrCfgJSON, err := NewCgrJsonCfgFromBytes([]byte(cfgJSONStr)); err != nil {
 		t.Error(err)
 	} else if err := cgrConfig.loadConfigSCfg(cgrCfgJSON); err == nil || err.Error() != expected {
@@ -1897,9 +1764,6 @@ func TestDiameterAgentConfig(t *testing.T) {
 		RequestProcessors: nil,
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.DiameterAgentCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -1924,9 +1788,6 @@ func TestRadiusAgentConfig(t *testing.T) {
 		RequestProcessors:  nil,
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.RadiusAgentCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -1947,9 +1808,6 @@ func TestDNSAgentConfig(t *testing.T) {
 		RequestProcessors: nil,
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.DNSAgentCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -1973,9 +1831,6 @@ func TestAttributeSConfig(t *testing.T) {
 		},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.AttributeSCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -1992,9 +1847,6 @@ func TestChargersConfig(t *testing.T) {
 		NestedFields:        false,
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.ChargerSCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2016,9 +1868,6 @@ func TestResourceSConfig(t *testing.T) {
 		},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.ResourceSCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2040,9 +1889,6 @@ func TestStatSConfig(t *testing.T) {
 		},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.StatSCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2062,9 +1908,6 @@ func TestThresholdSConfig(t *testing.T) {
 		},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.ThresholdSCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2090,9 +1933,6 @@ func TestRouteSConfig(t *testing.T) {
 		},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.RouteSCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2137,9 +1977,6 @@ func TestSessionSConfig(t *testing.T) {
 		},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.SessionSCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2169,9 +2006,6 @@ func TestFsAgentConfig(t *testing.T) {
 		},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.FsAgentCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2187,9 +2021,6 @@ func TestKamAgentConfig(t *testing.T) {
 		Timezone:      "",
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.KamAgentCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2211,9 +2042,6 @@ func TestAsteriskAgentConfig(t *testing.T) {
 		}},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.AsteriskAgentCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2227,9 +2055,6 @@ func TestFilterSConfig(t *testing.T) {
 		ApierSConns:    []string{},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.FilterSCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2252,9 +2077,6 @@ func TestLoaderConfig(t *testing.T) {
 		},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.LoaderCfg()
 	newConfig[0].Data = nil
 	if !reflect.DeepEqual(expected, newConfig) {
@@ -2273,9 +2095,6 @@ func TestDispatcherSConfig(t *testing.T) {
 		AnySubsystem:        true,
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.DispatcherSCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2292,9 +2111,6 @@ func TestSchedulerConfig(t *testing.T) {
 		DynaprepaidActionPlans: []string{},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.SchedulerCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2310,9 +2126,6 @@ func TestAnalyzerConfig(t *testing.T) {
 		TTL:             24 * time.Hour,
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.AnalyzerSCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2328,9 +2141,6 @@ func TestApierConfig(t *testing.T) {
 		EEsConns:        []string{},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.ApierCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2383,9 +2193,6 @@ func TestERSConfig(t *testing.T) {
 		PartialCacheTTL: time.Second,
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.ERsCfg()
 	newConfig.Readers[0].Fields = nil
 	if !reflect.DeepEqual(expected, newConfig) {
@@ -2432,9 +2239,6 @@ func TestEEsNoLksConfig(t *testing.T) {
 		},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.EEsNoLksCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2452,9 +2256,6 @@ func TestSIPAgentConfig(t *testing.T) {
 		RequestProcessors:   nil,
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.SIPAgentCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2506,9 +2307,6 @@ func TestRPCConnsConfig(t *testing.T) {
 		},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.RPCConns()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2566,9 +2364,6 @@ func TestTemplatesConfig(t *testing.T) {
 		}
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.TemplatesCfg()
 	newConfig["*cca"] = nil
 	newConfig["*asr"] = nil
@@ -2588,9 +2383,6 @@ func TestConfigsConfig(t *testing.T) {
 		RootDir: "/var/spool/cgrates/configs",
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.ConfigSCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2602,9 +2394,6 @@ func TestAPIBanConfig(t *testing.T) {
 		Keys: []string{},
 	}
 	cgrConfig := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	newConfig := cgrConfig.APIBanCfg()
 	if !reflect.DeepEqual(expected, newConfig) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(newConfig))
@@ -2613,27 +2402,18 @@ func TestAPIBanConfig(t *testing.T) {
 
 func TestRLockSections(t *testing.T) {
 	cgrCfg := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	cgrCfg.rLockSections()
 	cgrCfg.rUnlockSections()
 }
 
 func TestLockSections(t *testing.T) {
 	cgrCfg := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	cgrCfg.lockSections()
 	cgrCfg.unlockSections()
 }
 
 func TestRLockAndRUnlock(t *testing.T) {
 	cgrCfg := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	cgrCfg.RLocks("attributes", "ees", "general")
 	cgrCfg.RUnlocks("attributes", "ees", "general")
 }
@@ -3459,9 +3239,6 @@ func TestCgrCfgJSONDefaultApierCfg(t *testing.T) {
 func TestCgrCfgV1GetConfigAllConfig(t *testing.T) {
 	var rcv map[string]any
 	cgrCfg := NewDefaultCGRConfig()
-	if err != nil {
-		t.Error(err)
-	}
 	expected := cgrCfg.AsMapInterface(cgrCfg.GeneralCfg().RSRSep)
 	if err := cgrCfg.V1GetConfig(context.Background(), &SectionWithAPIOpts{Section: utils.EmptyString}, &rcv); err != nil {
 		t.Fatal(err)
@@ -4685,7 +4462,7 @@ func TestV1GetConfigSectionConfigs(t *testing.T) {
 
 	var result string
 	cfgCgr2 := NewDefaultCGRConfig()
-	if err = cfgCgr2.V1SetConfig(context.Background(), &SetConfigArgs{Config: reply, DryRun: true}, &result); err != nil {
+	if err := cfgCgr2.V1SetConfig(context.Background(), &SetConfigArgs{Config: reply, DryRun: true}, &result); err != nil {
 		t.Error(err)
 	} else if result != utils.OK {
 		t.Errorf("Unexpected result")
@@ -4694,7 +4471,7 @@ func TestV1GetConfigSectionConfigs(t *testing.T) {
 	}
 
 	cfgCgr2 = NewDefaultCGRConfig()
-	if err = cfgCgr2.V1SetConfig(context.Background(), &SetConfigArgs{Config: reply}, &result); err != nil {
+	if err := cfgCgr2.V1SetConfig(context.Background(), &SetConfigArgs{Config: reply}, &result); err != nil {
 		t.Error(err)
 	} else if result != utils.OK {
 		t.Errorf("Unexpected result")
@@ -5310,7 +5087,7 @@ func TestV1GetConfigAsJSONCoreS(t *testing.T) {
 	for _, section := range sortedCfgSections {
 		cfgCgr2.rldChans[section] = make(chan struct{}, 1)
 	}
-	if err = cfgCgr2.V1SetConfigFromJSON(context.Background(), &SetConfigFromJSONArgs{Config: reply, DryRun: true}, &result); err != nil {
+	if err := cfgCgr2.V1SetConfigFromJSON(context.Background(), &SetConfigFromJSONArgs{Config: reply, DryRun: true}, &result); err != nil {
 		t.Error(err)
 	} else if result != utils.OK {
 		t.Errorf("Unexpected result")
@@ -5320,7 +5097,7 @@ func TestV1GetConfigAsJSONCoreS(t *testing.T) {
 	for _, section := range sortedCfgSections {
 		cfgCgr2.rldChans[section] = make(chan struct{}, 1)
 	}
-	if err = cfgCgr2.V1SetConfigFromJSON(context.Background(), &SetConfigFromJSONArgs{Config: reply}, &result); err != nil {
+	if err := cfgCgr2.V1SetConfigFromJSON(context.Background(), &SetConfigFromJSONArgs{Config: reply}, &result); err != nil {
 		t.Error(err)
 	} else if result != utils.OK {
 		t.Errorf("Unexpected result")
@@ -5343,7 +5120,7 @@ func TestV1GetConfigAsJSONCheckConfigSanity(t *testing.T) {
 		cfgCgr2.rldChans[section] = make(chan struct{}, 1)
 	}
 
-	if err = cfgCgr2.V1SetConfigFromJSON(context.Background(), &SetConfigFromJSONArgs{Config: args}, &result); err == nil || err.Error() != expected {
+	if err := cfgCgr2.V1SetConfigFromJSON(context.Background(), &SetConfigFromJSONArgs{Config: args}, &result); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -5787,7 +5564,7 @@ func TestCallOnCGRConfig(t *testing.T) {
 func TestLoadCfgFromJSONWithLocksInvalidSeciton(t *testing.T) {
 	expected := "Invalid section: <invalidSection>"
 	cfg := NewDefaultCGRConfig()
-	if err = cfg.loadCfgWithLocks("/random/path", "invalidSection"); err == nil || err.Error() != expected {
+	if err := cfg.loadCfgWithLocks("/random/path", "invalidSection"); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -5946,7 +5723,7 @@ func TestCGRConfigGetDP(t *testing.T) {
 	exp := utils.MapStorage(cfg.AsMapInterface(cfg.generalCfg.RSRSep))
 	dp := cfg.GetDataProvider()
 	if !reflect.DeepEqual(dp, exp) {
-		t.Errorf("Expected %+v, received %+v", exp, err)
+		t.Errorf("Expected %+v, received %+v", exp, dp)
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -32,8 +32,6 @@ import (
 	"github.com/cgrates/cgrates/utils"
 )
 
-var cfg *CGRConfig
-
 func TestNewDefaultConfigError(t *testing.T) {
 	if _, err := newCGRConfig([]byte(CGRATES_CFG_JSON)); err != nil {
 		t.Error(err)
@@ -61,7 +59,7 @@ func TestNewCgrConfigFromBytesDecodeError(t *testing.T) {
 }
 
 func TestCgrCfgConfigSharing(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	SetCgrConfig(cfg)
 	cfgReturn := CgrConfig()
 	if !reflect.DeepEqual(cfgReturn, cfg) {
@@ -5533,7 +5531,7 @@ func TestLoadConfigFromReaderError(t *testing.T) {
 	cgrCfg := NewDefaultCGRConfig()
 	if err == nil || err.Error() != expectedErrFile {
 		t.Errorf("Expected %+v, receivewd %+v", expectedErrFile, err)
-	} else if err := cgrCfg.loadConfigFromReader(file, []func(*CgrJsonCfg) error{cfg.loadFromJSONCfg}, true); err == nil || err.Error() != expectedErr {
+	} else if err := cgrCfg.loadConfigFromReader(file, []func(*CgrJsonCfg) error{cgrCfg.loadFromJSONCfg}, true); err == nil || err.Error() != expectedErr {
 		t.Errorf("Expected %+v, received %+v", expectedErr, err)
 	}
 }
@@ -5547,7 +5545,7 @@ func TestLoadConfigFromReaderLoadFunctionsError(t *testing.T) {
 	expected := `json: cannot unmarshal number into Go struct field DbJsonCfg.Db_type of type string`
 	cgrCfg := NewDefaultCGRConfig()
 	if err := cgrCfg.loadConfigFromReader(strings.NewReader(cfgJSONStr),
-		[]func(jsonCfg *CgrJsonCfg) error{cfg.loadDataDBCfg},
+		[]func(jsonCfg *CgrJsonCfg) error{cgrCfg.loadDataDBCfg},
 		true); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}

--- a/config/configs_test.go
+++ b/config/configs_test.go
@@ -89,7 +89,7 @@ func TestNewCGRConfigFromPathWithoutEnv(t *testing.T) {
   }`
 	cfg := NewDefaultCGRConfig()
 
-	if err = cfg.loadConfigFromReader(strings.NewReader(cfgsJSONStr), []func(*CgrJsonCfg) error{cfg.loadFromJSONCfg}, true); err != nil {
+	if err := cfg.loadConfigFromReader(strings.NewReader(cfgsJSONStr), []func(*CgrJsonCfg) error{cfg.loadFromJSONCfg}, true); err != nil {
 		t.Fatal(err)
 	}
 	exp := "*env:NODE_ID"

--- a/config/configsanity_test.go
+++ b/config/configsanity_test.go
@@ -139,7 +139,7 @@ func TestConfigSanityCDRServer(t *testing.T) {
 }
 
 func TestConfigSanityLoaders(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.loaderCfg = LoaderSCfgs{
 		&LoaderSCfg{
 			Enabled: true,
@@ -249,7 +249,7 @@ func TestConfigSanityLoaders(t *testing.T) {
 }
 
 func TestConfigSanitySessionS(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.sessionSCfg = &SessionSCfg{
 		Enabled:           true,
 		TerminateAttempts: 0,
@@ -384,7 +384,7 @@ func TestConfigSanitySessionS(t *testing.T) {
 }
 
 func TestConfigSanityFreeSWITCHAgent(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.fsAgentCfg = &FsAgentCfg{
 		Enabled: true,
 	}
@@ -410,7 +410,7 @@ func TestConfigSanityFreeSWITCHAgent(t *testing.T) {
 }
 
 func TestConfigSanityKamailioAgent(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.kamAgentCfg = &KamAgentCfg{
 		Enabled: true,
 	}
@@ -432,7 +432,7 @@ func TestConfigSanityKamailioAgent(t *testing.T) {
 }
 
 func TestConfigSanityAsteriskAgent(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.asteriskAgentCfg = &AsteriskAgentCfg{
 		Enabled: true,
 	}
@@ -454,7 +454,7 @@ func TestConfigSanityAsteriskAgent(t *testing.T) {
 }
 
 func TestConfigSanityDAgent(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 
 	cfg.templates = FcTemplates{
 		utils.MetaEEs: {
@@ -589,7 +589,7 @@ func TestConfigSanityDAgent(t *testing.T) {
 }
 
 func TestConfigSanityRadiusAgent(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.radiusAgentCfg = &RadiusAgentCfg{
 		Enabled: true,
 		RequestProcessors: []*RequestProcessor{
@@ -709,7 +709,7 @@ func TestConfigSanityRadiusAgent(t *testing.T) {
 }
 
 func TestConfigSanityDNSAgent(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.dnsAgentCfg = &DNSAgentCfg{
 		Enabled: true,
 		RequestProcessors: []*RequestProcessor{
@@ -1090,7 +1090,7 @@ func TestConfigSanityChargerS(t *testing.T) {
 }
 
 func TestConfigSanityResourceLimiter(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.resourceSCfg = &ResourceSConfig{
 		Enabled:         true,
 		ThresholdSConns: []string{utils.MetaInternal},
@@ -1107,7 +1107,7 @@ func TestConfigSanityResourceLimiter(t *testing.T) {
 }
 
 func TestConfigSanityStatS(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.statsCfg = &StatSCfg{
 		Enabled:         true,
 		ThresholdSConns: []string{utils.MetaInternal},
@@ -1124,7 +1124,7 @@ func TestConfigSanityStatS(t *testing.T) {
 }
 
 func TestConfigSanityRouteS(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.routeSCfg.Enabled = true
 
 	cfg.routeSCfg.ResourceSConns = []string{utils.MetaInternal}
@@ -1178,7 +1178,7 @@ func TestConfigSanityRouteS(t *testing.T) {
 }
 
 func TestConfigSanityScheduler(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.schedulerCfg.Enabled = true
 
 	cfg.schedulerCfg.CDRsConns = []string{utils.MetaInternal}
@@ -1225,7 +1225,7 @@ func TestConfigSanityScheduler(t *testing.T) {
 }
 
 func TestConfigSanityEventReader(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.ersCfg = &ERsCfg{
 		Enabled:       true,
 		SessionSConns: []string{"unexistedConn"},
@@ -1693,7 +1693,7 @@ func TestConfigSanityRegistrarCDispatcher(t *testing.T) {
 }
 
 func TestConfigSanityStorDB(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.storDbCfg = &StorDbCfg{
 		Type: utils.MetaPostgres,
 		Opts: &StorDBOpts{
@@ -1740,7 +1740,7 @@ func TestConfigSanityAnalyzer(t *testing.T) {
 }
 
 func TestConfigSanityDataDB(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.dataDbCfg.Type = utils.MetaInternal
 
 	cfg.cacheCfg = &CacheCfg{
@@ -1841,7 +1841,7 @@ func TestConfigSanityDataDB(t *testing.T) {
 }
 
 func TestConfigSanityAPIer(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.apier.AttributeSConns = []string{utils.MetaInternal}
 
 	if err := cfg.checkConfigSanity(); err == nil || err.Error() != "<AttributeS> not enabled but requested by <APIerSv1> component" {
@@ -1867,7 +1867,7 @@ func TestConfigSanityAPIer(t *testing.T) {
 }
 
 func TestConfigSanityDispatcher(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.dispatcherSCfg = &DispatcherSCfg{
 		Enabled:         true,
 		AttributeSConns: []string{utils.MetaInternal},
@@ -1883,7 +1883,7 @@ func TestConfigSanityDispatcher(t *testing.T) {
 }
 
 func TestConfigSanityCacheS(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 
 	cfg.cacheCfg.Partitions = map[string]*CacheParamCfg{"wrong_partition_name": {Limit: 10}}
 	if err := cfg.checkConfigSanity(); err == nil || err.Error() != "<CacheS> partition <wrong_partition_name> not defined" {
@@ -1897,7 +1897,7 @@ func TestConfigSanityCacheS(t *testing.T) {
 }
 
 func TestConfigSanityFilterS(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.filterSCfg.StatSConns = []string{utils.MetaInternal}
 
 	if err := cfg.checkConfigSanity(); err == nil || err.Error() != "<Stats> not enabled but requested by <FilterS> component" {
@@ -2003,7 +2003,7 @@ func TestCheckConfigSanity(t *testing.T) {
 }
 
 func TestConfigSanityErs(t *testing.T) {
-	cfg = NewDefaultCGRConfig()
+	cfg := NewDefaultCGRConfig()
 	cfg.ersCfg.Enabled = true
 
 	cfg.ersCfg.SessionSConns = []string{}

--- a/config/corescfg_test.go
+++ b/config/corescfg_test.go
@@ -64,13 +64,13 @@ func TestCoreSloadFromJsonCfg(t *testing.T) {
 	coresJSONCfg := &CoreSJsonCfg{
 		Caps_stats_interval: utils.StringPointer("1ss"),
 	}
-	if err = alS.loadFromJSONCfg(coresJSONCfg); err == nil || err.Error() != expErr {
+	if err := alS.loadFromJSONCfg(coresJSONCfg); err == nil || err.Error() != expErr {
 		t.Errorf("Expected error: %s,received: %v", expErr, err)
 	}
 	coresJSONCfg = &CoreSJsonCfg{
 		Shutdown_timeout: utils.StringPointer("1ss"),
 	}
-	if err = alS.loadFromJSONCfg(coresJSONCfg); err == nil || err.Error() != expErr {
+	if err := alS.loadFromJSONCfg(coresJSONCfg); err == nil || err.Error() != expErr {
 		t.Errorf("Expected error: %s,received: %v", expErr, err)
 	}
 }

--- a/config/datadbcfg_test.go
+++ b/config/datadbcfg_test.go
@@ -79,9 +79,9 @@ func TestDataDbCfgloadFromJsonCfg(t *testing.T) {
 		},
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.dataDbCfg.loadFromJSONCfg(nil); err != nil {
+	if err := jsnCfg.dataDbCfg.loadFromJSONCfg(nil); err != nil {
 		t.Error(err)
-	} else if err = jsnCfg.dataDbCfg.loadFromJSONCfg(jsonCfg); err != nil {
+	} else if err := jsnCfg.dataDbCfg.loadFromJSONCfg(jsonCfg); err != nil {
 		t.Error(err)
 	} else {
 		if !reflect.DeepEqual(expected.Items[utils.MetaAccounts], jsnCfg.dataDbCfg.Items[utils.MetaAccounts]) {
@@ -148,7 +148,7 @@ func TestConnsloadFromJsonCfg(t *testing.T) {
 	}
 	expectedErrRmt := "Remote connection ID needs to be different than *internal"
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.dataDbCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expectedErrRmt {
+	if err := jsnCfg.dataDbCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expectedErrRmt {
 		t.Errorf("Expected %+v, received %+v", expectedErrRmt, err)
 	}
 
@@ -157,7 +157,7 @@ func TestConnsloadFromJsonCfg(t *testing.T) {
 	}
 	expectedErrRpl := "Replication connection ID needs to be different than *internal"
 	jsnCfg = NewDefaultCGRConfig()
-	if err = jsnCfg.dataDbCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expectedErrRpl {
+	if err := jsnCfg.dataDbCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expectedErrRpl {
 		t.Errorf("Expected %+v, received %+v", expectedErrRpl, err)
 	}
 }
@@ -600,7 +600,7 @@ func TestCloneDataDB(t *testing.T) {
 		},
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.dataDbCfg.loadFromJSONCfg(jsonCfg); err != nil {
+	if err := jsnCfg.dataDbCfg.loadFromJSONCfg(jsonCfg); err != nil {
 		t.Error(err)
 	} else {
 		rcv := jsnCfg.dataDbCfg.Clone()

--- a/config/diametercfg_test.go
+++ b/config/diametercfg_test.go
@@ -71,7 +71,7 @@ func TestDiameterAgentCfgloadFromJsonCfg(t *testing.T) {
 		},
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.diameterAgentCfg.loadFromJSONCfg(jsonCFG, jsnCfg.generalCfg.RSRSep); err != nil {
+	if err := jsnCfg.diameterAgentCfg.loadFromJSONCfg(jsonCFG, jsnCfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.diameterAgentCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.diameterAgentCfg))

--- a/config/dispatcherscfg_test.go
+++ b/config/dispatcherscfg_test.go
@@ -47,7 +47,7 @@ func TestDispatcherSCfgloadFromJsonCfg(t *testing.T) {
 		AnySubsystem:        true,
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.dispatcherSCfg.loadFromJSONCfg(jsonCfg); err != nil {
+	if err := jsnCfg.dispatcherSCfg.loadFromJSONCfg(jsonCfg); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.dispatcherSCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.dispatcherSCfg))

--- a/config/dnsagentcfg_test.go
+++ b/config/dnsagentcfg_test.go
@@ -76,7 +76,7 @@ func TestDNSAgentCfgloadFromJsonCfg(t *testing.T) {
 		v.ComputePath()
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.dnsAgentCfg.loadFromJSONCfg(jsnCfg, jsonCfg.generalCfg.RSRSep); err != nil {
+	if err := jsonCfg.dnsAgentCfg.loadFromJSONCfg(jsnCfg, jsonCfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(jsonCfg.dnsAgentCfg, expected) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.dnsAgentCfg))
@@ -107,7 +107,7 @@ func TestRequestProcessorloadFromJsonCfg(t *testing.T) {
 		Filters: []string{"filter1", "filter2"},
 		Flags:   utils.FlagsWithParams{"flag1": {}, "flag2": {}},
 	}
-	if err = dareq.loadFromJSONCfg(json, utils.InfieldSep); err != nil {
+	if err := dareq.loadFromJSONCfg(json, utils.InfieldSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, dareq) {
 		t.Errorf("Expected: %+v , received: %+v", utils.ToJSON(expected), utils.ToJSON(dareq))

--- a/config/eescfg_test.go
+++ b/config/eescfg_test.go
@@ -338,7 +338,7 @@ func TestEventExporterFieldloadFromJsonCfg(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.eesCfg.loadFromJSONCfg(eventExporterJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvExp); err == nil || err.Error() != expected {
+	if err := jsonCfg.eesCfg.loadFromJSONCfg(eventExporterJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvExp); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -357,7 +357,7 @@ func TestEventExporterFieldloadFromJsonCfg1(t *testing.T) {
 	}
 	expected := "no template with id: <>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.eesCfg.loadFromJSONCfg(eventExporterJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvExp); err == nil || err.Error() != expected {
+	if err := jsonCfg.eesCfg.loadFromJSONCfg(eventExporterJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvExp); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -495,7 +495,7 @@ func TestEESCacheloadFromJsonCfg(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.eesCfg.loadFromJSONCfg(eesCfg, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvExp); err == nil || err.Error() != expected {
+	if err := jsonCfg.eesCfg.loadFromJSONCfg(eesCfg, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvExp); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -876,7 +876,7 @@ func TestEEsCfgloadFromJsonCfgCase2(t *testing.T) {
 		}
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.eesCfg.loadFromJSONCfg(jsonCfg, msgTemplates, jsnCfg.generalCfg.RSRSep, jsnCfg.dfltEvExp); err != nil {
+	if err := jsnCfg.eesCfg.loadFromJSONCfg(jsonCfg, msgTemplates, jsnCfg.generalCfg.RSRSep, jsnCfg.dfltEvExp); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expectedCfg, jsnCfg.eesCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expectedCfg), utils.ToJSON(jsnCfg.eesCfg))

--- a/config/erscfg_test.go
+++ b/config/erscfg_test.go
@@ -191,7 +191,7 @@ func TestEventReaderloadFromJsonCfg(t *testing.T) {
 	jsonCfg := NewDefaultCGRConfig()
 
 	eventReader := new(EventReaderCfg)
-	if err = eventReader.loadFromJSONCfg(nil, jsonCfg.templates, jsonCfg.generalCfg.RSRSep); err != nil {
+	if err := eventReader.loadFromJSONCfg(nil, jsonCfg.templates, jsonCfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	}
 }
@@ -206,7 +206,7 @@ func TestEventReaderloadFromJsonCase1(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsoncfg := NewDefaultCGRConfig()
-	if err = jsoncfg.ersCfg.loadFromJSONCfg(cfgJSON, jsoncfg.templates, jsoncfg.generalCfg.RSRSep, jsoncfg.dfltEvRdr, jsoncfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
+	if err := jsoncfg.ersCfg.loadFromJSONCfg(cfgJSON, jsoncfg.templates, jsoncfg.generalCfg.RSRSep, jsoncfg.dfltEvRdr, jsoncfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 	cfgJson := &ERsJsonCfg{
@@ -229,7 +229,7 @@ func TestEventReaderloadFromJsonCase3(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsoncfg := NewDefaultCGRConfig()
-	if err = jsoncfg.ersCfg.loadFromJSONCfg(cfgJSON, jsoncfg.templates, jsoncfg.generalCfg.RSRSep, jsoncfg.dfltEvRdr, jsoncfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
+	if err := jsoncfg.ersCfg.loadFromJSONCfg(cfgJSON, jsoncfg.templates, jsoncfg.generalCfg.RSRSep, jsoncfg.dfltEvRdr, jsoncfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -397,7 +397,7 @@ func TestERSloadFromJsonCfg(t *testing.T) {
 		Readers: nil,
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err != nil {
+	if err := jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	}
 }
@@ -416,7 +416,7 @@ func TestEventReaderFieldsloadFromJsonCfg(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
+	if err := jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -436,7 +436,7 @@ func TestERSloadFromJsonCase1(t *testing.T) {
 	}
 	expected := "no template with id: <>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
+	if err := jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -455,7 +455,7 @@ func TestERSloadFromJsonCase2(t *testing.T) {
 	}
 	expected := "no template with id: <>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
+	if err := jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -615,7 +615,7 @@ func TestERSloadFromJsonCase3(t *testing.T) {
 		v.ComputePath()
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, msgTemplates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err != nil {
+	if err := jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, msgTemplates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expectedERsCfg, jsonCfg.ersCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expectedERsCfg), utils.ToJSON(jsonCfg.ersCfg))
@@ -779,7 +779,7 @@ func TestERSloadFromJsonCase4(t *testing.T) {
 		v.ComputePath()
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, msgTemplates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err != nil {
+	if err := jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, msgTemplates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expectedERsCfg, jsonCfg.ersCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expectedERsCfg), utils.ToJSON(jsonCfg.ersCfg))
@@ -800,7 +800,7 @@ func TestEventReaderCacheDumpFieldsloadFromJsonCfg(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
+	if err := jsonCfg.ersCfg.loadFromJSONCfg(cfgJSON, jsonCfg.templates, jsonCfg.generalCfg.RSRSep, jsonCfg.dfltEvRdr, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }

--- a/config/filterscfg_test.go
+++ b/config/filterscfg_test.go
@@ -36,7 +36,7 @@ func TestFilterSCfgloadFromJsonCfg(t *testing.T) {
 		ApierSConns:    []string{utils.ConcatenatedKey(utils.MetaInternal, utils.MetaApier), "*conn1"},
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.filterSCfg.loadFromJSONCfg(cfgJSONS); err != nil {
+	if err := jsnCfg.filterSCfg.loadFromJSONCfg(cfgJSONS); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.filterSCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.filterSCfg))

--- a/config/generalcfg_test.go
+++ b/config/generalcfg_test.go
@@ -71,7 +71,7 @@ func TestGeneralCfgloadFromJsonCfg(t *testing.T) {
 		FailedPostsTTL:   2,
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.generalCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsnCfg.generalCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.generalCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.generalCfg))
@@ -90,7 +90,7 @@ func TestGeneralParseDurationCfgloadFromJsonCfg(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.generalCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.generalCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %v", expected, err)
 	}
 
@@ -98,7 +98,7 @@ func TestGeneralParseDurationCfgloadFromJsonCfg(t *testing.T) {
 		Reply_timeout: utils.StringPointer("1ss"),
 	}
 	jsonCfg = NewDefaultCGRConfig()
-	if err = jsonCfg.generalCfg.loadFromJSONCfg(cfgJSON1); err == nil || err.Error() != expected {
+	if err := jsonCfg.generalCfg.loadFromJSONCfg(cfgJSON1); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %v", expected, err)
 	}
 
@@ -106,7 +106,7 @@ func TestGeneralParseDurationCfgloadFromJsonCfg(t *testing.T) {
 		Failed_posts_ttl: utils.StringPointer("1ss"),
 	}
 	jsonCfg = NewDefaultCGRConfig()
-	if err = jsonCfg.generalCfg.loadFromJSONCfg(cfgJSON2); err == nil || err.Error() != expected {
+	if err := jsonCfg.generalCfg.loadFromJSONCfg(cfgJSON2); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %v", expected, err)
 	}
 
@@ -114,7 +114,7 @@ func TestGeneralParseDurationCfgloadFromJsonCfg(t *testing.T) {
 		Locking_timeout: utils.StringPointer("1ss"),
 	}
 	jsonCfg = NewDefaultCGRConfig()
-	if err = jsonCfg.generalCfg.loadFromJSONCfg(cfgJSON3); err == nil || err.Error() != expected {
+	if err := jsonCfg.generalCfg.loadFromJSONCfg(cfgJSON3); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %v", expected, err)
 	}
 

--- a/config/httpagntcfg_test.go
+++ b/config/httpagntcfg_test.go
@@ -81,7 +81,7 @@ func TestHttpAgentCfgsloadFromJsonCfgCase1(t *testing.T) {
 	}
 	expected[0].RequestProcessors[0].ReplyFields[0].ComputePath()
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.httpAgentCfg.loadFromJSONCfg(cfgJSON, jsnCfg.generalCfg.RSRSep); err != nil {
+	if err := jsnCfg.httpAgentCfg.loadFromJSONCfg(cfgJSON, jsnCfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(&expected, &jsnCfg.httpAgentCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.httpAgentCfg))
@@ -221,7 +221,7 @@ func TestHttpAgentCfgsloadFromJsonCfgCase2(t *testing.T) {
 	expected[0].RequestProcessors[1].ReplyFields[0].ComputePath()
 	expected[0].RequestProcessors[1].RequestFields[0].ComputePath()
 	cfgJsn := NewDefaultCGRConfig()
-	if err = cfgJsn.httpAgentCfg.loadFromJSONCfg(cfgJSON, cfgJsn.generalCfg.RSRSep); err != nil {
+	if err := cfgJsn.httpAgentCfg.loadFromJSONCfg(cfgJSON, cfgJsn.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, cfgJsn.httpAgentCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(cfgJsn.httpAgentCfg))
@@ -262,7 +262,7 @@ func TestHttpAgentCfgloadFromJsonCfgCase3(t *testing.T) {
 		}},
 	}
 	var httpcfg HTTPAgentCfg
-	if err = httpcfg.loadFromJSONCfg(jsnhttpCfg, utils.InfieldSep); err != nil {
+	if err := httpcfg.loadFromJSONCfg(jsnhttpCfg, utils.InfieldSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, httpcfg) {
 		t.Errorf("Expected: %+v \n, received: %+v", utils.ToJSON(expected), utils.ToJSON(httpcfg))
@@ -341,7 +341,7 @@ func TestHttpAgentCfgloadFromJsonCfgCase4(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.httpAgentCfg.loadFromJSONCfg(cfgJSON, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
+	if err := jsonCfg.httpAgentCfg.loadFromJSONCfg(cfgJSON, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -484,7 +484,7 @@ func TestHttpAgentCfgappendHttpAgntProcCfgs(t *testing.T) {
 	}
 	expected.RequestProcessors[0].ReplyFields[0].ComputePath()
 	expected.RequestProcessors[1].ReplyFields[0].ComputePath()
-	if err = initial.appendHTTPAgntProcCfgs(proceses, utils.InfieldSep); err != nil {
+	if err := initial.appendHTTPAgntProcCfgs(proceses, utils.InfieldSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, initial) {
 		t.Errorf("Expected: %+v , received: %+v", utils.ToJSON(expected), utils.ToJSON(initial))

--- a/config/httpcfg_test.go
+++ b/config/httpcfg_test.go
@@ -70,7 +70,7 @@ func TestHTTPCfgloadFromJsonCfg(t *testing.T) {
 		},
 	}
 	cfgJsn := NewDefaultCGRConfig()
-	if err = cfgJsn.httpCfg.loadFromJSONCfg(cfgJSONStr); err != nil {
+	if err := cfgJsn.httpCfg.loadFromJSONCfg(cfgJSONStr); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected.AsMapInterface(), cfgJsn.httpCfg.AsMapInterface()) {
 		t.Errorf("Expected %+v \n, received %+v", expected.AsMapInterface(), cfgJsn.httpCfg.AsMapInterface())

--- a/config/kamagentcfg_test.go
+++ b/config/kamagentcfg_test.go
@@ -47,7 +47,7 @@ func TestKamAgentCfgloadFromJsonCfg(t *testing.T) {
 		Timezone:      "Local",
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.kamAgentCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsnCfg.kamAgentCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.kamAgentCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.kamAgentCfg))
@@ -87,7 +87,7 @@ func TestKamConnCfgloadFromJsonCfg(t *testing.T) {
 		Address:    "127.0.0.1:8448",
 		Reconnects: 5,
 	}
-	if err = kamcocfg.loadFromJSONCfg(json); err != nil {
+	if err := kamcocfg.loadFromJSONCfg(json); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, kamcocfg) {
 		t.Errorf("Expected: %+v , received: %+v", utils.ToJSON(expected), utils.ToJSON(kamcocfg))

--- a/config/listencfg_test.go
+++ b/config/listencfg_test.go
@@ -42,7 +42,7 @@ func TestListenCfgloadFromJsonCfg(t *testing.T) {
 		HTTPTLSListen:    "127.0.0.1:2280",
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.listenCfg.loadFromJSONCfg(jsonCfg); err != nil {
+	if err := jsnCfg.listenCfg.loadFromJSONCfg(jsonCfg); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.listenCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.listenCfg))

--- a/config/loadercgrcfg_test.go
+++ b/config/loadercgrcfg_test.go
@@ -47,7 +47,7 @@ func TestLoaderCgrCfgloadFromJsonCfg(t *testing.T) {
 		GapiToken:       json.RawMessage{13, 16},
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.loaderCgrCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsnCfg.loaderCgrCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.loaderCgrCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.loaderCgrCfg))

--- a/config/loaderscfg_test.go
+++ b/config/loaderscfg_test.go
@@ -145,7 +145,7 @@ func TestLoaderSCfgloadFromJsonCfgCase4(t *testing.T) {
 	}
 	expected := "no template with id: <>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.loaderCfg[0].loadFromJSONCfg(cfg, jsonCfg.templates, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
+	if err := jsonCfg.loaderCfg[0].loadFromJSONCfg(cfg, jsonCfg.templates, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -194,7 +194,7 @@ func TestLoaderSCfgloadFromJsonCfgCase5(t *testing.T) {
 		},
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.loaderCfg[0].loadFromJSONCfg(cfg, msgTemplates, jsonCfg.generalCfg.RSRSep); err != nil {
+	if err := jsonCfg.loaderCfg[0].loadFromJSONCfg(cfg, msgTemplates, jsonCfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(jsonCfg.loaderCfg[0].Data[0].Fields[0], expectedFields[0].Data[0].Fields[0]) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expectedFields[0].Data[0].Fields[0]), utils.ToJSON(jsonCfg.loaderCfg[0].Data[0].Fields[0]))
@@ -210,7 +210,7 @@ func TestLoaderSCfgloadFromJsonCfgCase6(t *testing.T) {
 		Data: &[]*LoaderJsonDataType{nil},
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.loaderCfg[0].loadFromJSONCfg(cfg, jsonCfg.templates, jsonCfg.generalCfg.RSRSep); err != nil {
+	if err := jsonCfg.loaderCfg[0].loadFromJSONCfg(cfg, jsonCfg.templates, jsonCfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	}
 }
@@ -462,7 +462,7 @@ func TestLockFolderRelativePath(t *testing.T) {
 		Tp_out_dir:      utils.StringPointer("/var/spool/cgrates/loader/out/"),
 	}
 	expPath := path.Join(ldr.LockFilePath)
-	if err = ldr.loadFromJSONCfg(jsonCfg, map[string][]*FCTemplate{}, utils.InfieldSep); err != nil {
+	if err := ldr.loadFromJSONCfg(jsonCfg, map[string][]*FCTemplate{}, utils.InfieldSep); err != nil {
 		t.Error(err)
 	} else if ldr.LockFilePath != expPath {
 		t.Errorf("Expected %v \n but received \n %v", expPath, ldr.LockFilePath)
@@ -486,7 +486,7 @@ func TestLockFolderNonRelativePath(t *testing.T) {
 		Tp_out_dir:      utils.StringPointer("/var/spool/cgrates/loader/out/"),
 	}
 	expPath := path.Join("/tmp/", utils.ResourcesCsv)
-	if err = ldr.loadFromJSONCfg(jsonCfg, map[string][]*FCTemplate{}, utils.InfieldSep); err != nil {
+	if err := ldr.loadFromJSONCfg(jsonCfg, map[string][]*FCTemplate{}, utils.InfieldSep); err != nil {
 		t.Error(err)
 	} else if ldr.LockFilePath != expPath {
 		t.Errorf("Expected %v \n but received \n %v", expPath, ldr.LockFilePath)
@@ -510,7 +510,7 @@ func TestLockFolderIsDir(t *testing.T) {
 	}
 	expPath := path.Join("/tmp")
 
-	if err = ldr.loadFromJSONCfg(jsonCfg, map[string][]*FCTemplate{}, utils.InfieldSep); err != nil {
+	if err := ldr.loadFromJSONCfg(jsonCfg, map[string][]*FCTemplate{}, utils.InfieldSep); err != nil {
 		t.Error(err)
 	} else if ldr.LockFilePath != expPath {
 		t.Errorf("Expected %v \n but received \n %v", expPath, ldr.LockFilePath)

--- a/config/mailercfg_test.go
+++ b/config/mailercfg_test.go
@@ -38,7 +38,7 @@ func TestMailerCfgloadFromJsonCfg(t *testing.T) {
 		MailerFromAddr: "cgr-mailer@localhost.localdomain",
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.mailerCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsnCfg.mailerCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.mailerCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.mailerCfg))

--- a/config/migratorcfg_test.go
+++ b/config/migratorcfg_test.go
@@ -83,7 +83,7 @@ func TestMigratorCgrCfgloadFromJsonCfg(t *testing.T) {
 		},
 	}
 	cfg := NewDefaultCGRConfig()
-	if err = cfg.migratorCgrCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := cfg.migratorCgrCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, cfg.migratorCgrCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(cfg.migratorCgrCfg))

--- a/config/objdp_test.go
+++ b/config/objdp_test.go
@@ -134,7 +134,7 @@ func TestFieldAsInterfaceObjDPValid1(t *testing.T) {
 	} else if rcv != 1 {
 		t.Errorf("Expected %+v, received %+v", 1, rcv)
 	}
-	if _, err = objDp.FieldAsInterface([]string{"val"}); err == nil || err != utils.ErrNotFound {
+	if _, err := objDp.FieldAsInterface([]string{"val"}); err == nil || err != utils.ErrNotFound {
 		t.Error(err)
 	}
 }

--- a/config/radiuscfg_test.go
+++ b/config/radiuscfg_test.go
@@ -121,7 +121,7 @@ func TestRadiusAgentCfgloadFromJsonCfgCase1(t *testing.T) {
 		r.ComputePath()
 	}
 	cfg := NewDefaultCGRConfig()
-	if err = cfg.radiusAgentCfg.loadFromJSONCfg(cfgJSON, cfg.generalCfg.RSRSep); err != nil {
+	if err := cfg.radiusAgentCfg.loadFromJSONCfg(cfgJSON, cfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, cfg.radiusAgentCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(cfg.radiusAgentCfg))
@@ -154,7 +154,7 @@ func TestRadiusAgentCfgloadFromJsonCfgCase2(t *testing.T) {
 	}
 	if jsonCfg, err := NewCGRConfigFromJSONStringWithDefaults(cfgJSONStr); err != nil {
 		t.Error(err)
-	} else if err = jsonCfg.radiusAgentCfg.loadFromJSONCfg(cfgJSON, jsonCfg.generalCfg.RSRSep); err != nil {
+	} else if err := jsonCfg.radiusAgentCfg.loadFromJSONCfg(cfgJSON, jsonCfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(jsonCfg.radiusAgentCfg.RequestProcessors[0].ID, expected.RequestProcessors[0].ID) {
 		t.Errorf("Expected %+v, received %+v", utils.ToJSON(jsonCfg.radiusAgentCfg.RequestProcessors[0].ID),
@@ -172,7 +172,7 @@ func TestRadiusAgentCfgloadFromJsonCfgCase3(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.radiusAgentCfg.loadFromJSONCfg(cfgJSON, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
+	if err := jsonCfg.radiusAgentCfg.loadFromJSONCfg(cfgJSON, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }

--- a/config/ralscfg_test.go
+++ b/config/ralscfg_test.go
@@ -68,7 +68,7 @@ func TestRalsCfgFromJsonCfgCase1(t *testing.T) {
 		},
 	}
 	cfg := NewDefaultCGRConfig()
-	if err = cfg.ralsCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := cfg.ralsCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, cfg.ralsCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(cfg.ralsCfg))
@@ -83,7 +83,7 @@ func TestRalsCfgFromJsonCfgCase2(t *testing.T) {
 	}
 	expected := "time: unknown unit \"hh\" in duration \"189hh\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.ralsCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.ralsCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }

--- a/config/registrarccfg_test.go
+++ b/config/registrarccfg_test.go
@@ -162,7 +162,7 @@ func TestDispatcherHCfgloadFromJsonCfg(t *testing.T) {
 		},
 	}
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.registrarCCfg.loadFromJSONCfg(jsonCfg); err != nil {
+	if err := jsnCfg.registrarCCfg.loadFromJSONCfg(jsonCfg); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsnCfg.registrarCCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsnCfg.registrarCCfg))
@@ -258,7 +258,7 @@ func TestDispatcherCfgParseWithNanoSec(t *testing.T) {
 	}
 	expErrMessage := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.registrarCCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expErrMessage {
+	if err := jsnCfg.registrarCCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expErrMessage {
 		t.Errorf("Expected %+v \n, recevied %+v", expErrMessage, err)
 	}
 }
@@ -271,7 +271,7 @@ func TestDispatcherCfgParseWithNanoSec2(t *testing.T) {
 	}
 	expErrMessage := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsnCfg := NewDefaultCGRConfig()
-	if err = jsnCfg.registrarCCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expErrMessage {
+	if err := jsnCfg.registrarCCfg.loadFromJSONCfg(jsonCfg); err == nil || err.Error() != expErrMessage {
 		t.Errorf("Expected %+v \n, recevied %+v", expErrMessage, err)
 	}
 }

--- a/config/resourcescfg_test.go
+++ b/config/resourcescfg_test.go
@@ -50,7 +50,7 @@ func TestResourceSConfigloadFromJsonCfgCase1(t *testing.T) {
 		},
 	}
 	cfg := NewDefaultCGRConfig()
-	if err = cfg.resourceSCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := cfg.resourceSCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, cfg.resourceSCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(cfg.resourceSCfg))
@@ -80,7 +80,7 @@ func TestResourceSConfigloadFromJsonCfgCase2(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"2ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.resourceSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.resourceSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }

--- a/config/routescfg_test.go
+++ b/config/routescfg_test.go
@@ -67,14 +67,14 @@ func TestRouteSCfgloadFromJsonCfg(t *testing.T) {
 		},
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.routeSCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsonCfg.routeSCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsonCfg.routeSCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.routeSCfg))
 	}
 	jsonCfg.routeSCfg.Opts.loadFromJSONCfg(nil)
-	if reflect.DeepEqual(nil, jsonCfg.routeSCfg.Opts) {
-		t.Error(err)
+	if jsonCfg.routeSCfg.Opts == nil {
+		t.Error("expecting jsonCfg.routeSCfg.Opts to be different from nil")
 	}
 }
 

--- a/config/schedulercfg_test.go
+++ b/config/schedulercfg_test.go
@@ -42,7 +42,7 @@ func TestSchedulerCfgloadFromJsonCfg(t *testing.T) {
 		DynaprepaidActionPlans: []string{"randomPlan"},
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.schedulerCfg.loadFromJSONCfg(cfgJSONS); err != nil {
+	if err := jsonCfg.schedulerCfg.loadFromJSONCfg(cfgJSONS); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsonCfg.schedulerCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.schedulerCfg))

--- a/config/sessionscfg_test.go
+++ b/config/sessionscfg_test.go
@@ -131,7 +131,7 @@ func TestSessionSCfgloadFromJsonCfgCase1(t *testing.T) {
 		},
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsonCfg.sessionSCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.sessionSCfg))
@@ -144,7 +144,7 @@ func TestSessionSCfgloadFromJsonCfgCase2(t *testing.T) {
 	}
 	expected := "Replication connection ID needs to be different than *internal"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -155,7 +155,7 @@ func TestSessionSCfgloadFromJsonCfgCase3(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -166,7 +166,7 @@ func TestSessionSCfgloadFromJsonCfgCase5(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -177,7 +177,7 @@ func TestSessionSCfgloadFromJsonCfgCase7(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -188,7 +188,7 @@ func TestSessionSCfgloadFromJsonCfgCase8(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -199,28 +199,28 @@ func TestSessionSCfgloadFromJsonCfgCase9(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 	cfgJSON1 := &SessionSJsonCfg{
 		Session_ttl_last_used: utils.StringPointer("1ss"),
 	}
 	jsonCfg = NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON1); err == nil || err.Error() != expected {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON1); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 	cfgJSON2 := &SessionSJsonCfg{
 		Session_ttl_max_delay: utils.StringPointer("1ss"),
 	}
 	jsonCfg = NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON2); err == nil || err.Error() != expected {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON2); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 	cfgJSON3 := &SessionSJsonCfg{
 		Session_ttl_usage: utils.StringPointer("1ss"),
 	}
 	jsonCfg = NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON3); err == nil || err.Error() != expected {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON3); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -273,7 +273,7 @@ func TestSessionSCfgloadFromJsonCfgCase10(t *testing.T) {
 		},
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(jsonCfg.sessionSCfg, expected) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.sessionSCfg))
@@ -288,7 +288,7 @@ func TestSessionSCfgloadFromJsonCfgCase11(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sessionSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -541,7 +541,7 @@ func TestFsAgentCfgloadFromJsonCfgCase1(t *testing.T) {
 		},
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.fsAgentCfg.loadFromJSONCfg(fsAgentJsnCfg); err != nil {
+	if err := jsonCfg.fsAgentCfg.loadFromJSONCfg(fsAgentJsnCfg); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsonCfg.fsAgentCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.fsAgentCfg))
@@ -554,7 +554,7 @@ func TestFsAgentCfgloadFromJsonCfgCase2(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.fsAgentCfg.loadFromJSONCfg(fsAgentJsnCfg); err == nil || err.Error() != expected {
+	if err := jsonCfg.fsAgentCfg.loadFromJSONCfg(fsAgentJsnCfg); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -565,7 +565,7 @@ func TestFsAgentCfgloadFromJsonCfgCase3(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.fsAgentCfg.loadFromJSONCfg(fsAgentJsnCfg); err == nil || err.Error() != expected {
+	if err := jsonCfg.fsAgentCfg.loadFromJSONCfg(fsAgentJsnCfg); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -710,7 +710,7 @@ func TestFsConnCfgloadFromJsonCfg(t *testing.T) {
 		Alias:                "127.0.0.1:8448",
 		MaxReconnectInterval: 1 * time.Nanosecond,
 	}
-	if err = fscocfg.loadFromJSONCfg(json); err != nil {
+	if err := fscocfg.loadFromJSONCfg(json); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, fscocfg) {
 		t.Errorf("Expected: %+v , received: %+v", utils.ToJSON(expected), utils.ToJSON(fscocfg))
@@ -775,7 +775,7 @@ func TestAsteriskAgentCfgloadFromJsonCfg(t *testing.T) {
 		}},
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.asteriskAgentCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsonCfg.asteriskAgentCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsonCfg.asteriskAgentCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.asteriskAgentCfg))
@@ -857,13 +857,13 @@ func TestAsteriskConnCfgloadFromJsonCfg(t *testing.T) {
 		Reconnects:           5,
 		MaxReconnectInterval: 1 * time.Nanosecond,
 	}
-	if err = asconcfg.loadFromJSONCfg(json); err != nil {
+	if err := asconcfg.loadFromJSONCfg(json); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, asconcfg) {
 		t.Errorf("Expected: %+v , received: %+v", utils.ToJSON(expected), utils.ToJSON(asconcfg))
 	}
 	json.Max_reconnect_interval = utils.StringPointer("test")
-	if err = asconcfg.loadFromJSONCfg(json); err == nil {
+	if err := asconcfg.loadFromJSONCfg(json); err == nil {
 		t.Error(err)
 	}
 }

--- a/config/sipagentcfg_test.go
+++ b/config/sipagentcfg_test.go
@@ -81,7 +81,7 @@ func TestSIPAgentCfgloadFromJsonCfgCase1(t *testing.T) {
 		r.ComputePath()
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sipAgentCfg.loadFromJSONCfg(cfgJSONS, jsonCfg.generalCfg.RSRSep); err != nil {
+	if err := jsonCfg.sipAgentCfg.loadFromJSONCfg(cfgJSONS, jsonCfg.generalCfg.RSRSep); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsonCfg.sipAgentCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.sipAgentCfg))
@@ -94,7 +94,7 @@ func TestSIPAgentCfgloadFromJsonCfgCase2(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sipAgentCfg.loadFromJSONCfg(cfgJSON, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
+	if err := jsonCfg.sipAgentCfg.loadFromJSONCfg(cfgJSON, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -138,7 +138,7 @@ func TestSIPAgentCfgloadFromJsonCfgCase5(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sipAgentCfg.loadFromJSONCfg(sipAgent, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
+	if err := jsonCfg.sipAgentCfg.loadFromJSONCfg(sipAgent, jsonCfg.generalCfg.RSRSep); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }

--- a/config/statscfg_test.go
+++ b/config/statscfg_test.go
@@ -51,7 +51,7 @@ func TestStatSCfgloadFromJsonCfgCase1(t *testing.T) {
 		},
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.statsCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsonCfg.statsCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsonCfg.statsCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.statsCfg))
@@ -69,7 +69,7 @@ func TestStatSCfgloadFromJsonCfgCase2(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.statsCfg.loadFromJSONCfg(statscfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.statsCfg.loadFromJSONCfg(statscfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }

--- a/config/stordbcfg_test.go
+++ b/config/stordbcfg_test.go
@@ -89,7 +89,7 @@ func TestStoreDbCfgloadFromJsonCfgCase1(t *testing.T) {
 		},
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.storDbCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsonCfg.storDbCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected.Items[utils.MetaSessionsCosts], jsonCfg.storDbCfg.Items[utils.MetaSessionsCosts]) {
 		t.Errorf("Expected %+v \n, recevied %+v", utils.ToJSON(expected.Items[utils.MetaSessionsCosts]),
@@ -110,7 +110,7 @@ func TestStoreDbCfgloadFromJsonCfgCase2(t *testing.T) {
 	}
 	expected := "Replication connection ID needs to be different than *internal"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.storDbCfg.loadFromJSONCfg(storDbJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.storDbCfg.loadFromJSONCfg(storDbJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", storDbJSON, expected)
 	}
 }
@@ -121,7 +121,7 @@ func TestStoreDbCfgloadFromJsonCfgCase3(t *testing.T) {
 	}
 	expected := "Remote connection ID needs to be different than *internal"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.storDbCfg.loadFromJSONCfg(storDbJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.storDbCfg.loadFromJSONCfg(storDbJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", storDbJSON, expected)
 	}
 }

--- a/config/suretaxcfg_test.go
+++ b/config/suretaxcfg_test.go
@@ -88,7 +88,7 @@ func TestSureTaxCfgloadFromJsonCfgCase1(t *testing.T) {
 		TaxExemptionCodeList: NewRSRParsersMustCompile(utils.EmptyString, utils.InfieldSep),
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsonCfg.sureTaxCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.sureTaxCfg))
@@ -101,7 +101,7 @@ func TestSureTaxCfgloadFromJsonCfgCase2(t *testing.T) {
 	}
 	expected := "time: invalid location name"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -112,7 +112,7 @@ func TestSureTaxCfgloadFromJsonCfgCase3(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -123,7 +123,7 @@ func TestSureTaxCfgloadFromJsonCfgCase4(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -134,7 +134,7 @@ func TestSureTaxCfgloadFromJsonCfgCase5(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -145,7 +145,7 @@ func TestSureTaxCfgloadFromJsonCfgCase6(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -156,7 +156,7 @@ func TestSureTaxCfgloadFromJsonCfgCase7(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -167,7 +167,7 @@ func TestSureTaxCfgloadFromJsonCfgCase8(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -178,7 +178,7 @@ func TestSureTaxCfgloadFromJsonCfgCase9(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -189,7 +189,7 @@ func TestSureTaxCfgloadFromJsonCfgCase10(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -200,7 +200,7 @@ func TestSureTaxCfgloadFromJsonCfgCase11(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -211,7 +211,7 @@ func TestSureTaxCfgloadFromJsonCfgCase12(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -222,7 +222,7 @@ func TestSureTaxCfgloadFromJsonCfgCase13(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -233,7 +233,7 @@ func TestSureTaxCfgloadFromJsonCfgCase14(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -244,7 +244,7 @@ func TestSureTaxCfgloadFromJsonCfgCase15(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -255,7 +255,7 @@ func TestSureTaxCfgloadFromJsonCfgCase16(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -266,7 +266,7 @@ func TestSureTaxCfgloadFromJsonCfgCase17(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }
@@ -277,7 +277,7 @@ func TestSureTaxCfgloadFromJsonCfgCase18(t *testing.T) {
 	}
 	expected := "invalid converter terminator in rule: <a{*>"
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.sureTaxCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }

--- a/config/thresholdscfg_test.go
+++ b/config/thresholdscfg_test.go
@@ -52,7 +52,7 @@ func TestThresholdSCfgloadFromJsonCfgCase1(t *testing.T) {
 		},
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.thresholdSCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsonCfg.thresholdSCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsonCfg.thresholdSCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.thresholdSCfg))
@@ -71,7 +71,7 @@ func TestThresholdSCfgloadFromJsonCfgCase2(t *testing.T) {
 	}
 	expected := "time: unknown unit \"ss\" in duration \"1ss\""
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.thresholdSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
+	if err := jsonCfg.thresholdSCfg.loadFromJSONCfg(cfgJSON); err == nil || err.Error() != expected {
 		t.Errorf("Expected %+v, received %+v", expected, err)
 	}
 }

--- a/config/tlscfg_test.go
+++ b/config/tlscfg_test.go
@@ -44,7 +44,7 @@ func TestTlsCfgloadFromJsonCfg(t *testing.T) {
 		ServerPolicy:     3,
 	}
 	jsonCfg := NewDefaultCGRConfig()
-	if err = jsonCfg.tlsCfg.loadFromJSONCfg(cfgJSON); err != nil {
+	if err := jsonCfg.tlsCfg.loadFromJSONCfg(cfgJSON); err != nil {
 		t.Error(err)
 	} else if !reflect.DeepEqual(expected, jsonCfg.tlsCfg) {
 		t.Errorf("Expected %+v \n, received %+v", utils.ToJSON(expected), utils.ToJSON(jsonCfg.tlsCfg))


### PR DESCRIPTION
Removed many leftover error checks for NewDefaultCGRConfig,
which does not return an error anymore.