### PR TITLE
Optimize removeFilterIndexesForFilter func 

### DIFF
--- a/engine/libindex.go
+++ b/engine/libindex.go
@@ -783,32 +783,32 @@ func UpdateFilterIndex(dm *DataManager, oldFlt, newFlt *Filter) (err error) {
 	return
 }
 
-// removeFilterIndexesForFilter removes the itemID for the index keys
-// used to remove the old indexes when a filter is updated
+// removeFilterIndexesForFilter removes itemIDs from the specified filter index keys.
+// Used to update the index map when a filter is modified.
 func removeFilterIndexesForFilter(dm *DataManager, idxItmType, tnt string,
-	removeIndexKeys []string, itemIDs utils.StringSet) (err error) {
+	removeIndexKeys []string, itemIDs utils.StringSet) error {
 	refID := guardian.Guardian.GuardIDs(utils.EmptyString,
 		config.CgrConfig().GeneralCfg().LockingTimeout, idxItmType+tnt)
 	defer guardian.Guardian.UnguardIDs(refID)
-	for _, idxKey := range removeIndexKeys { // delete old filters indexes for this item
-		var remIndx map[string]utils.StringSet
-		if remIndx, err = dm.GetIndexes(idxItmType, tnt,
-			idxKey, true, false); err != nil {
-			if err != utils.ErrNotFound {
-				return
-			}
-			err = nil
-			continue
-		}
-		for idx := range itemIDs {
-			remIndx[idxKey].Remove(idx)
-		}
 
-		if err = dm.SetIndexes(idxItmType, tnt, remIndx, true, utils.NonTransactional); err != nil {
-			return
+	// Retrieve current filter indexes.
+	fltrIdx, err := dm.GetIndexes(idxItmType, tnt, utils.EmptyString, true, false)
+	if err != nil {
+		if err != utils.ErrNotFound {
+			return err
+		}
+		return nil
+	}
+
+	// Remove itemIDs from the specified index keys.
+	for _, idxKey := range removeIndexKeys {
+		for itemID := range itemIDs {
+			fltrIdx[idxKey].Remove(itemID)
 		}
 	}
-	return
+
+	// Store the updated indexes.
+	return dm.SetIndexes(idxItmType, tnt, fltrIdx, true, utils.NonTransactional)
 }
 
 // IsDynamicDPPath check dynamic path with ~*stats, ~*resources, ~*accounts, ~*libphonenumber, ~*asm to not be indexed


### PR DESCRIPTION
Previously made two trips (get and set) for each group of items from an index key being removed. Now, we fetch indexes once at the beginning and store the updated indexes once at the end.

There was a difference compared to the previous v0.10 implementation regarding the get/set behaviour. On v0.11, we used to get only the items separately for each index and update only that index. Even though it might have been more efficient, trips to the db are still too expensive so it didn't matter much in the end.