### PR TITLE
Improve engine setup helpers

### DIFF
--- a/general_tests/api_escape_char_it_test.go
+++ b/general_tests/api_escape_char_it_test.go
@@ -55,12 +55,10 @@ func TestEscapeCharacters(t *testing.T) {
 
 }`
 
-	testEnv := TestEnvironment{
-		Name: "TestEscapeCharacters",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigJSON: content,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	/*
 		When escape sequences are written manually, like \u0000 in the csv file, they are not interpreted as

--- a/general_tests/at_topup_it_test.go
+++ b/general_tests/at_topup_it_test.go
@@ -21,7 +21,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 package general_tests
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 	"time"
@@ -112,13 +111,11 @@ TRIGGER_1001,,*min_balance,0,false,0,,,main,*data,,,,,,,,,,ACT_USAGE_1GB,
 TRIGGER_1001,,*balance_expired,,true,0,,,main,*data,,,,,,,,,,ACT_TOPUP_INITIAL,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
-		LogBuffer:  &bytes.Buffer{},
 	}
-	// defer fmt.Println(testEnv.LogBuffer)
-	client, _ := testEnv.Setup(t, 10)
+	client, _ := ng.Run(t)
 
 	// helper functions
 	i := 0

--- a/general_tests/attributes_it_test.go
+++ b/general_tests/attributes_it_test.go
@@ -1116,13 +1116,11 @@ cgrates.org,FLTR_OR_DESTINATION_MATCH,*destinations,~*req.Destination,DST_20;DST
 cgrates.org,FLTR_DESTINATION_MATCH,*destinations,~*req.Destination,DST_10,`,
 	}
 
-	testEnv := TestEnvironment{
-		Name: "TestAttributesDestinationFilters",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("SetAttributesThroughAPI", func(t *testing.T) {
 		var reply string
@@ -1302,13 +1300,11 @@ cgrates.org,ATTR_ARITH,,,,,*req.3-4,*difference,3;4,,
 cgrates.org,ATTR_ARITH,,,,,*req.MultiplyBetweenVariables,*multiply,~*req.Elem1;~*req.Elem2,,`,
 	}
 
-	testEnv := TestEnvironment{
-		Name: "TestAttributesArith",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("SetAttributesThroughAPI", func(t *testing.T) {
 		var reply string

--- a/general_tests/authorize_event_sms_data_it_test.go
+++ b/general_tests/authorize_event_sms_data_it_test.go
@@ -44,12 +44,11 @@ func TestSSv1AuthorizeEventSMS(t *testing.T) {
 	default:
 		t.Fatal("Unknown Database type")
 	}
-	testEnv := TestEnvironment{
-		Name:       "TestSSv1AuthorizeEventSMS",
+	ng := TestEngine{
 		ConfigPath: path.Join(*utils.DataDir, "conf", "samples", cfgDir),
 		TpPath:     path.Join(*utils.DataDir, "tariffplans", "testit"),
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("AuthorizeEventSMS", func(t *testing.T) {
 		args := &sessions.V1AuthorizeArgs{

--- a/general_tests/balance_blocker_it_test.go
+++ b/general_tests/balance_blocker_it_test.go
@@ -96,11 +96,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	testNg := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := testNg.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("Authorize", func(t *testing.T) {
@@ -199,11 +199,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("InterimUpdate30s", func(t *testing.T) {
@@ -324,11 +324,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("ProcessEvent", func(t *testing.T) {
@@ -465,11 +465,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("Authorize", func(t *testing.T) {
@@ -568,11 +568,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("InterimUpdate30s", func(t *testing.T) {
@@ -693,11 +693,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("ProcessEvent", func(t *testing.T) {
@@ -837,11 +837,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("Authorize", func(t *testing.T) {
@@ -941,11 +941,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("InterimUpdate30s", func(t *testing.T) {
@@ -1067,11 +1067,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("ProcessEvent", func(t *testing.T) {
@@ -1209,11 +1209,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("Authorize", func(t *testing.T) {
@@ -1313,11 +1313,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("InterimUpdate30s", func(t *testing.T) {
@@ -1439,11 +1439,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 
 	t.Run("ProcessEvent", func(t *testing.T) {

--- a/general_tests/balance_it_test.go
+++ b/general_tests/balance_it_test.go
@@ -107,13 +107,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,sms,1001,2014-01-14T00:00:00Z,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
-		Name: "TestBalanceBlocker",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("CheckInitialBalance", func(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
@@ -353,13 +351,11 @@ cgrates.org,sms,1001,2014-01-14T00:00:00Z,RP_SMS,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_VOICE,`,
 	}
 
-	testEnv := TestEnvironment{
-		Name: "TestBalanceFactor",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("CheckInitialBalance", func(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
@@ -871,13 +867,11 @@ ACT_TOPUP_MONETARY,*cdrlog,"{""BalanceID"":""~*acnt.BalanceID""}",,,,,,,,,,,,,,
 ACT_TOPUP_SMS,*topup_reset,,,balance_sms,*sms,,*any,,,*unlimited,,1000,10,false,false,10`,
 	}
 
-	testEnv := TestEnvironment{
-		Name: "TestBalanceCDRLog",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("CheckInitialBalances", func(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
@@ -1261,12 +1255,11 @@ RP_MONETARY,DR_MONETARY,*any,10`,
 		utils.RatingProfilesCsv: `#Tenant,Category,Subject,ActivationTime,RatingPlanId,RatesFallbackSubject`,
 	}
 
-	testEnv := TestEnvironment{
-		Name:       "TestBalanceFactor",
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	t.Run("SetAccount", func(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
 		var reply string

--- a/general_tests/balance_timings_it_test.go
+++ b/general_tests/balance_timings_it_test.go
@@ -121,12 +121,11 @@ HALF1,*any,*any,*any,*any,00:00:00;11:59:59
 HALF2,*any,*any,*any,*any,12:00:00;23:59:59`,
 	}
 
-	testEnv := TestEnvironment{
-		Name:       "TestBalanceTimings",
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(50 * time.Millisecond)
 
 	t.Run("TimingIsActiveAt", func(t *testing.T) {
@@ -371,11 +370,10 @@ RP_1001,DR_1002_20CNT,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_1001,`,
 	}
 
-	testEnv := TestEnvironment{
-		Name:       "TestBalanceTimings",
+	ng := TestEngine{
 		ConfigJSON: content,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(50 * time.Millisecond)
 
 	t.Run("SetTimings", func(t *testing.T) {
@@ -657,11 +655,10 @@ RP_1001,DR_1002_20CNT,*any,10`,
 cgrates.org,call,1001,2014-01-14T00:00:00Z,RP_1001,`,
 	}
 
-	testEnv := TestEnvironment{
-		Name:       "TestBalanceTimings",
+	ng := TestEngine{
 		ConfigJSON: content,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	time.Sleep(50 * time.Millisecond)
 
 	t.Run("SetTimings", func(t *testing.T) {

--- a/general_tests/cdrlog_ees_it_test.go
+++ b/general_tests/cdrlog_ees_it_test.go
@@ -180,13 +180,11 @@ func TestCdrLogEes(t *testing.T) {
 
 	}
 
-	testEnv := TestEnvironment{
-		Name: "TTestCdrLogEes",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    map[string]string{},
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("AddBalanceCdrLog", func(t *testing.T) {
 		var reply string

--- a/general_tests/ees_it_test.go
+++ b/general_tests/ees_it_test.go
@@ -113,11 +113,10 @@ func TestEEsExportEventChanges(t *testing.T) {
 
 }`
 
-	testEnv := TestEnvironment{
-		Name:       "TestEEsExportEventChanges",
+	ng := TestEngine{
 		ConfigJSON: content,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("SetAttributeProfile", func(t *testing.T) {
 		attrPrf := &engine.AttributeProfileWithAPIOpts{
@@ -388,13 +387,10 @@ func TestEEsReplayFailedPosts(t *testing.T) {
 
 }`, failedDir)
 
-	testEnv := TestEnvironment{
-		Name:       "TestEEsReplayFailedPosts",
+	ng := TestEngine{
 		ConfigJSON: content,
-		// LogBuffer:  &bytes.Buffer{},
 	}
-	// defer fmt.Println(testEnv.LogBuffer)
-	client, _ := testEnv.Setup(t, 0)
+	client, _ := ng.Run(t)
 
 	// helper to sort slices
 	less := func(a, b string) bool { return a < b }

--- a/general_tests/ers_linenr_it_test.go
+++ b/general_tests/ers_linenr_it_test.go
@@ -105,11 +105,11 @@ func TestERsLineNr(t *testing.T) {
 }`, csvFd, procFd, fwvFd, procFd, xmlFd, procFd)
 
 	buf := &bytes.Buffer{}
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		LogBuffer:  buf,
 	}
-	_, _ = testEnv.Setup(t, 0)
+	_, _ = ng.Run(t)
 
 	fileIdx := 0
 	createFile := func(t *testing.T, dir, ext, content string) {

--- a/general_tests/fallback_depth_it_test.go
+++ b/general_tests/fallback_depth_it_test.go
@@ -112,12 +112,12 @@ cgrates.org,call,DEFAULT,,RP_DEFAULT,`,
 	}
 
 	buf := &bytes.Buffer{}
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 		LogBuffer:  buf,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	cdrIdx := 0
 	processCDR := func(t *testing.T, dest string, shouldFail bool) engine.EventCost {

--- a/general_tests/filterhttp_it_test.go
+++ b/general_tests/filterhttp_it_test.go
@@ -165,13 +165,11 @@ cgrates.org,ATTR_ACNT_1001,*any,FLTR_HTTP,,,*req.OfficeGroup,*http#[` + srv.URL 
 cgrates.org,ATTR_DEST,*any,FLTR_DST_1002;FLTR_DEST,,,*req.Supplier,*constant,Supplier1,,`,
 	}
 
-	testEnv := TestEnvironment{
-		Name: "TestFilterHTTP",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("FilterHTTPFullEvent", func(t *testing.T) {
 

--- a/general_tests/get_account_cost_it_test.go
+++ b/general_tests/get_account_cost_it_test.go
@@ -35,13 +35,11 @@ import (
 var aSummaryBefore *engine.AccountSummary
 
 func TestGetAccountCost(t *testing.T) {
-	testEnv := TestEnvironment{
-		Name: "TestGetAccountCost",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigPath: path.Join(*utils.DataDir, "conf", "samples", "rerate_cdrs_mysql"),
 		TpPath:     path.Join(*utils.DataDir, "tariffplans", "reratecdrs"),
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	CGRID := utils.GenUUID()
 

--- a/general_tests/kafka_ssl_it_test.go
+++ b/general_tests/kafka_ssl_it_test.go
@@ -129,10 +129,10 @@ func TestKafkaSSL(t *testing.T) {
 
 }`, brokerSSLURL, mainTopic, brokerPlainURL, processedTopic, brokerSSLURL, mainTopic)
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 	}
-	client, _ := testEnv.Setup(t, 0)
+	client, _ := ng.Run(t)
 
 	createKafkaTopics(t, brokerPlainURL, true, mainTopic, processedTopic)
 

--- a/general_tests/lib_test.go
+++ b/general_tests/lib_test.go
@@ -52,39 +52,53 @@ func newRPCClient(cfg *config.ListenCfg) (c *birpc.Client, err error) {
 	}
 }
 
-// TestEnvironment holds the setup parameters and configurations
+// TestEngine holds the setup parameters and configurations
 // required for running integration tests.
-type TestEnvironment struct {
-	Name       string            // usually the name of the test
-	ConfigPath string            // file path to the main configuration file
-	ConfigJSON string            // contains the configuration JSON content if ConfigPath is missing
-	TpPath     string            // specifies the path to the tariff plans
-	TpFiles    map[string]string // maps CSV filenames to their content for tariff plan loading
-	LogBuffer  io.Writer         // captures the log output of the test environment
-	// Encoding   string         // specifies the data encoding type (e.g., JSON, GOB)
+type TestEngine struct {
+	ConfigPath     string            // path to the main configuration file
+	ConfigJSON     string            // configuration JSON content (used if ConfigPath is empty)
+	LogBuffer      io.Writer         // captures log output of the test environment
+	PreserveDataDB bool              // prevents automatic data_db flush when set
+	PreserveStorDB bool              // prevents automatic stor_db flush when set
+	TpPath         string            // path to the tariff plans
+	TpFiles        map[string]string // CSV data for tariff plans: filename -> content
+
+	// PreStartHook executes custom logic relying on CGRConfig
+	// before starting cgr-engine.
+	PreStartHook func(*testing.T, *config.CGRConfig)
 }
 
-// Setup initializes the testing environment using the provided configuration. It loads the configuration
-// from a specified path or creates a new one if the path is not provided. The method starts the engine,
-// establishes an RPC client connection, and loads CSV data if provided. It returns an RPC client and the
-// configuration.
-func (env TestEnvironment) Setup(t *testing.T, engineDelay int) (*birpc.Client, *config.CGRConfig) {
+// Run initializes a cgr-engine instance for testing, loads tariff plans (if available) and returns
+// an RPC client and the CGRConfig object. It calls t.Fatal on any setup failure.
+func (env TestEngine) Run(t *testing.T) (*birpc.Client, *config.CGRConfig) {
 	t.Helper()
 
-	var cfg *config.CGRConfig
+	// Parse config files.
+	var cfgPath string
 	switch {
-	case env.ConfigPath != "":
-		var err error
-		cfg, err = config.NewCGRConfigFromPath(env.ConfigPath)
-		if err != nil {
-			t.Fatalf("failed to init config from path %s: %v", env.ConfigPath, err)
+	case env.ConfigJSON != "":
+		cfgPath = t.TempDir()
+		filePath := filepath.Join(cfgPath, "cgrates.json")
+		if err := os.WriteFile(filePath, []byte(env.ConfigJSON), 0644); err != nil {
+			t.Fatal(err)
 		}
+	case env.ConfigPath != "":
+		cfgPath = env.ConfigPath
 	default:
-		cfg, env.ConfigPath = initCfg(t, env.ConfigJSON)
+		t.Fatal("missing config source")
+	}
+	cfg, err := config.NewCGRConfigFromPath(cfgPath)
+	if err != nil {
+		t.Fatalf("could not init config from path %s: %v", cfgPath, err)
 	}
 
-	flushDBs(t, cfg, true, true)
-	startEngine(t, cfg, env.ConfigPath, engineDelay, env.LogBuffer)
+	flushDBs(t, cfg, !env.PreserveDataDB, !env.PreserveStorDB)
+
+	if env.PreStartHook != nil {
+		env.PreStartHook(t, cfg)
+	}
+
+	startEngine(t, cfg, env.LogBuffer)
 
 	client, err := newRPCClient(cfg.ListenCfg())
 	if err != nil {
@@ -100,24 +114,23 @@ func (env TestEnvironment) Setup(t *testing.T, engineDelay int) (*birpc.Client, 
 	return client, cfg
 }
 
-// initCfg creates a new CGRConfig from the provided configuration content string.
-// It generates a temporary directory and file path, writes the content to the configuration
-// file, and returns the created CGRConfig and the configuration directory path.
-func initCfg(t *testing.T, cfgContent string) (cfg *config.CGRConfig, cfgPath string) {
+func waitForService(t *testing.T, ctx *context.Context, client *birpc.Client, service string) {
 	t.Helper()
-	if cfgContent == utils.EmptyString {
-		t.Fatal("ConfigJSON is required but empty")
+	method := service + ".Ping"
+	backoff := utils.FibDuration(time.Millisecond, 0)
+	var reply any
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("%s service did not become available: %v", service, ctx.Err())
+		default:
+			err := client.Call(context.Background(), method, nil, &reply)
+			if err == nil && reply == utils.Pong {
+				return
+			}
+			time.Sleep(backoff())
+		}
 	}
-	cfgPath = t.TempDir()
-	filePath := filepath.Join(cfgPath, "cgrates.json")
-	if err := os.WriteFile(filePath, []byte(cfgContent), 0644); err != nil {
-		t.Fatal(err)
-	}
-	cfg, err := config.NewCGRConfigFromPath(cfgPath)
-	if err != nil {
-		t.Fatalf("failed to init config from path %s: %v", cfgPath, err)
-	}
-	return cfg, cfgPath
 }
 
 // loadCSVs loads tariff plan data from CSV files into the service. It handles directory creation and file
@@ -134,10 +147,16 @@ func loadCSVs(t *testing.T, client *birpc.Client, tpPath, customTpPath string, c
 		}
 		paths = append(paths, customTpPath)
 	}
-
-	if tpPath != utils.EmptyString {
+	if tpPath != "" {
 		paths = append(paths, tpPath)
 	}
+	if len(paths) == 0 {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	waitForService(t, ctx, client, utils.APIerSv1)
 
 	var reply string
 	for _, path := range paths {
@@ -165,16 +184,16 @@ func flushDBs(t *testing.T, cfg *config.CGRConfig, flushDataDB, flushStorDB bool
 }
 
 // startEngine starts the CGR engine process with the provided configuration. It writes engine logs to the
-// provided logBuffer (if any) and waits for the engine to be ready.
-func startEngine(t *testing.T, cfg *config.CGRConfig, cfgPath string, waitEngine int, logBuffer io.Writer) {
+// provided logBuffer (if any).
+func startEngine(t *testing.T, cfg *config.CGRConfig, logBuffer io.Writer) {
 	t.Helper()
 	binPath, err := exec.LookPath("cgr-engine")
 	if err != nil {
-		t.Fatal("could not find cgr-engine executable")
+		t.Fatal(err)
 	}
 	engine := exec.Command(
 		binPath,
-		"-config_path", cfgPath,
+		"-config_path", cfg.ConfigPath,
 		"-logger", utils.MetaStdLog,
 	)
 	if logBuffer != nil {
@@ -186,7 +205,7 @@ func startEngine(t *testing.T, cfg *config.CGRConfig, cfgPath string, waitEngine
 	}
 	t.Cleanup(func() {
 		if err := engine.Process.Kill(); err != nil {
-			t.Logf("failed to kill cgr-engine process (%d): %v", engine.Process.Pid, err)
+			t.Errorf("failed to kill cgr-engine process (%d): %v", engine.Process.Pid, err)
 		}
 	})
 	fib := utils.FibDuration(time.Millisecond, 0)
@@ -199,5 +218,4 @@ func startEngine(t *testing.T, cfg *config.CGRConfig, cfgPath string, waitEngine
 	if err != nil {
 		t.Fatalf("starting cgr-engine on port %s failed: %v", cfg.ListenCfg().RPCJSONListen, err)
 	}
-	time.Sleep(time.Duration(waitEngine) * time.Millisecond)
 }

--- a/general_tests/process_message_it_test.go
+++ b/general_tests/process_message_it_test.go
@@ -80,11 +80,11 @@ RP_ANY,DR_ANY,*any,10`,
 cgrates.org,sms,subj_test,,RP_ANY,`,
 	}
 
-	testEnv := TestEnvironment{
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, 10)
+	client, _ := ng.Run(t)
 
 	setAccount := func(t *testing.T, acnt string, balance float64) {
 		t.Helper()

--- a/general_tests/rerate_cdrs_it_test.go
+++ b/general_tests/rerate_cdrs_it_test.go
@@ -46,13 +46,11 @@ func TestRerateCDRs(t *testing.T) {
 	default:
 		t.Fatal("Unknown Database type")
 	}
-	testEnv := TestEnvironment{
-		Name: "TestRerateCDRs",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigPath: path.Join(*utils.DataDir, "conf", "samples", cfgDir),
 		TpPath:     path.Join(*utils.DataDir, "tariffplans", "reratecdrs"),
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	CGRID := utils.GenUUID()
 

--- a/general_tests/rpsubj_set_it_test.go
+++ b/general_tests/rpsubj_set_it_test.go
@@ -85,13 +85,11 @@ RP_DATA,DR_DATA,*any,10`,
 cgrates.org,data,RPF_DATA,2022-01-14T00:00:00Z,RP_DATA,`,
 	}
 
-	testEnv := TestEnvironment{
-		Name: "TestRatingSubjectSet",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("CheckInitialBalance", func(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // wait for tps to be loaded
@@ -215,13 +213,11 @@ RP_DATA,DR_DATA,*any,10`,
 cgrates.org,data,1001,2022-01-14T00:00:00Z,RP_DATA,`,
 	}
 
-	testEnv := TestEnvironment{
-		Name: "TestRatingSubjectSetDefault",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("CheckInitialBalance", func(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // wait for tps to be loaded

--- a/general_tests/set_rmv_prfl_dlay_it_test.go
+++ b/general_tests/set_rmv_prfl_dlay_it_test.go
@@ -47,13 +47,11 @@ func TestSetRemoveProfilesWithCachingDelay(t *testing.T) {
 	default:
 		t.Fatal("Unknown Database type")
 	}
-	testEnv := TestEnvironment{
-		Name: "TestSetRemoveProfilesWithCachingDelay",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigPath: path.Join(*utils.DataDir, "conf", "samples", cfgDir),
 		TpPath:     path.Join(*utils.DataDir, "tariffplans", "tutorial"),
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("RemoveTPFromFolder", func(t *testing.T) {
 		var reply string

--- a/general_tests/shared_subject_it_test.go
+++ b/general_tests/shared_subject_it_test.go
@@ -121,13 +121,11 @@ cgrates.org,call,Subject1,2014-01-14T00:00:00Z,RP_Subject1,
 cgrates.org,call,Subject2,2014-01-14T00:00:00Z,RP_Subject2,`,
 	}
 
-	testEnv := TestEnvironment{
-		Name: "TestSharedSubject",
-		// Encoding:   *encoding,
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("Cost1001->1002", func(t *testing.T) {
 		var reply []*utils.EventWithFlags

--- a/general_tests/stats_export_it_test.go
+++ b/general_tests/stats_export_it_test.go
@@ -88,11 +88,10 @@ func TestStatsEEsExport(t *testing.T) {
 
 }`
 
-	testEnv := TestEnvironment{
-		Name:       "TestStatsEEsExport",
+	ng := TestEngine{
 		ConfigJSON: content,
 	}
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("SetStatProfile", func(t *testing.T) {
 		var reply string

--- a/general_tests/transfer_balance_it_test.go
+++ b/general_tests/transfer_balance_it_test.go
@@ -92,14 +92,11 @@ ACT_TRANSFER,*transfer_balance,"{""DestinationAccountID"":""cgrates.org:ACC_DEST
 ACT_TRANSFER,*cdrlog,,,,,,,,,,,,,,,`,
 	}
 
-	testEnv := TestEnvironment{
-		Name:       "TestTransferBalance",
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
-		// LogBuffer:  &bytes.Buffer{},
 	}
-	// defer fmt.Println(testEnv.LogBuffer)
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 
 	t.Run("CheckInitialBalances", func(t *testing.T) {
 		time.Sleep(10 * time.Millisecond) // wait for tps to be loaded

--- a/general_tests/trends_schedule_it_test.go
+++ b/general_tests/trends_schedule_it_test.go
@@ -77,13 +77,12 @@ cgrates.org,TREND_2,@every 2s,Stats1_2,,-1,-1,1,*last,1,false,`,
 cgrates.org,Stats1_1,*string:~*req.Account:1001,,,,,*tcc;*acd;*tcd,,,,,
 cgrates.org,Stats1_2,*string:~*req.Account:1002,,,,,*sum#~*req.Usage;*pdd,,,,,`}
 
-	testEnv := TestEnvironment{
-		Name:       "TestTrendSchedule",
+	ng := TestEngine{
 		ConfigJSON: content,
 		TpFiles:    tpFiles,
 	}
 
-	client, _ := testEnv.Setup(t, *utils.WaitRater)
+	client, _ := ng.Run(t)
 	t.Run("CheckTrendSchedule", func(t *testing.T) {
 		var scheduled int
 		if err := client.Call(context.Background(), utils.TrendSv1ScheduleQueries,


### PR DESCRIPTION
- added hook support (executed after parsing config but before starting engine)
- made db resets configurable
- merged config parsing helper with the main Setup function
- renamed TestEnvironment.Setup -> TestEngine.Run as it represents the setup for a single cgr-engine instance
- removed engineDelay parameter. Added helper to wait up to 200ms for the APIerSv1 service to be up and running to prevent 'can't find service' errors.
- replaced t.Log with t.Error for engine process kill error
- improved option comments