### PR TITLE
Revise go role cache clean tasks

### DIFF
--- a/data/ansible/roles/go/tasks/main.yaml
+++ b/data/ansible/roles/go/tasks/main.yaml
@@ -45,10 +45,19 @@
     mode: "0644"
   when: install_go | bool
 
-# Using file module since go clean seems to only rm -rf the specified path for modcache
+- name: Get Go modcache path
+  ansible.builtin.command: go env GOMODCACHE
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin"
+  register: gomodcache_path
+  changed_when: false
+  when: go_clean_modcache
+
+# Using file module since go clean --modcache is just a wrapper for rm -rf $GOMODCACHE
 - name: Clean Go modcache
+  become: true
   ansible.builtin.file:
-    path: "{{ ansible_env.HOME }}/go/pkg/mod"
+    path: "{{ gomodcache_path.stdout }}"
     state: absent
   when: go_clean_modcache
 
@@ -58,4 +67,4 @@
     PATH: "{{ ansible_env.PATH }}:/usr/local/go/bin"
   register: cache_clean_result
   when: go_clean_build_cache
-  changed_when: "'rm -rf' in cache_clean_result.stderr"
+  changed_when: "'rm -rf' in cache_clean_result.stdout"


### PR DESCRIPTION
Use go env GOMODCACHE for path resolution
Add become: true to prevent permission issues
Check stdout instead of stderr for go clean -x --cache