### PR TITLE
cast cached resource into the correct type

### DIFF
--- a/resources/resources.go
+++ b/resources/resources.go
@@ -343,7 +343,14 @@ func (rS *ResourceS) storeResources(ctx *context.Context) {
 			utils.Logger.Warning(fmt.Sprintf("<%s> failed retrieving from cache resource with ID: %s", utils.ResourceS, rID))
 			continue
 		}
-		r := rIf.(*resource)
+		r := &resource{
+			Resource: rIf.(*utils.Resource),
+
+			// NOTE: dirty is hardcoded to true, otherwise resources would
+			// never be stored.
+			// Previously, dirty was part of the cached resource.
+			dirty: utils.BoolPointer(true),
+		}
 		r.lock(utils.EmptyString)
 		if err := rS.storeResource(ctx, r); err != nil {
 			failedRIDs = append(failedRIDs, rID) // record failure so we can schedule it for next backup

--- a/resources/resources_test.go
+++ b/resources/resources_test.go
@@ -2866,19 +2866,16 @@ func TestResourcesStoreResources(t *testing.T) {
 		},
 	}
 
-	value := &resource{
-		Resource: &utils.Resource{
-			Tenant: "cgrates.org",
-			ID:     "testResource",
-		},
-		dirty: utils.BoolPointer(true),
+	value := &utils.Resource{
+		Tenant: "cgrates.org",
+		ID:     "testResource",
 	}
 
 	engine.Cache.SetWithoutReplicate(utils.CacheResources, "Res1", value, nil, true,
 		utils.NonTransactional)
 
 	explog := fmt.Sprintf("CGRateS <> [WARNING] <%s> failed saving Resource with ID: %s, error: %s\n",
-		utils.ResourceS, value.Resource.ID, utils.ErrNoDatabaseConn.Error())
+		utils.ResourceS, value.ID, utils.ErrNoDatabaseConn.Error())
 	exp := &ResourceS{
 		storedResources: utils.StringSet{
 			"Res1": struct{}{},
@@ -5883,12 +5880,9 @@ func TestResourcesRunBackupStop(t *testing.T) {
 		loopStopped: make(chan struct{}, 1),
 		stopBackup:  make(chan struct{}),
 	}
-	value := &resource{
-		Resource: &utils.Resource{
-			Tenant: tnt,
-			ID:     resID,
-		},
-		dirty: utils.BoolPointer(true),
+	value := &utils.Resource{
+		Tenant: tnt,
+		ID:     resID,
 	}
 	engine.Cache.SetWithoutReplicate(utils.CacheResources, resID, value, nil, true, "")
 


### PR DESCRIPTION
and ensure it is wrapped to allow locking