### PR TITLE
Fix GORM pagination with zero limit/offset + GetCDRs refactoring

### DIFF
--- a/engine/storage_sql.go
+++ b/engine/storage_sql.go
@@ -218,8 +218,12 @@ func (sqls *SQLStorage) GetCDRs(ctx *context.Context, qryFltr []*Filter, opts ma
 	if maxItems < limit+offset {
 		return nil, fmt.Errorf("sum of limit and offset exceeds maxItems")
 	}
-	q = q.Limit(limit)
-	q = q.Offset(offset)
+	if limit > 0 {
+		q = q.Limit(limit)
+	}
+	if offset > 0 {
+		q = q.Offset(offset)
+	}
 
 	// Execute query
 	results := make([]*utils.CDRSQLTable, 0)


### PR DESCRIPTION
Previously, q.Limit(0) was always set, causing GORM to return no records since limit=0 was interpreted as "get 0 records" rather than "no limit". Now we only set limit and offset when they're > 0, which makes pagination behave correctly with default values.