### PR TITLE
Fix context lifecycle in scheduled actions

### DIFF
--- a/actions/actions.go
+++ b/actions/actions.go
@@ -268,7 +268,7 @@ func (aS *ActionS) asapExecuteActions(ctx *context.Context, sActs *scheduledActs
 					utils.ActionS, sActs.tenant, sActs.apID, err))
 			return
 		}
-		if err = sActs.Execute(); err != nil { // cannot remove due to errors on execution
+		if err = sActs.Execute(ctx); err != nil { // cannot remove due to errors on execution
 			return
 		}
 		delete(ap.Targets[sActs.trgTyp], sActs.trgID)

--- a/actions/actions_test.go
+++ b/actions/actions_test.go
@@ -1051,7 +1051,6 @@ func TestACScheduledActions(t *testing.T) {
 			trgTyp:   utils.MetaStats,
 			trgID:    "ID_TEST",
 			schedule: utils.EmptyString,
-			ctx:      context.Background(),
 			data:     mapStorage,
 		},
 	}


### PR DESCRIPTION
Remove ctx field from scheduledActs struct and create a fresh context when actions execute via cron. This prevents "context canceled" errors that occurred when stored contexts from API calls were used for delayed execution. The context is now properly received from the caller in case of "*asap" actions.