### PR TITLE
Fix rsyslog config to capture logs across distros

### DIFF
--- a/data/conf/logging/rsyslog.conf
+++ b/data/conf/logging/rsyslog.conf
@@ -1,4 +1,4 @@
-if ($programname startswith 'cgr-engine' or $programname startswith 'CGRateS') then {
+if ($programname startswith 'cgr-engine' or $programname startswith 'CGRateS' or $msg contains 'CGRateS') then {
     action(type="omfile" File="/var/log/cgrates/CGRateS.log")
     stop
 }


### PR DESCRIPTION
Add three conditions to properly capture CGRateS logs:

- programname startswith 'cgr-engine': catches logs from external libraries that don't use our syslogger (e.g. diameter conn errors)
- programname startswith 'CGRateS': handles deb-based distros where our syslog tag becomes the program name
- msg contains 'CGRateS': handles rpm-based distros where systemd journal overrides programname but our tag remains in message content