### PR TITLE
allow nesting for events built inside NMAAsCGREvent

### DIFF
--- a/agents/libagents.go
+++ b/agents/libagents.go
@@ -42,7 +42,7 @@ func processRequest(ctx *context.Context, reqProcessor *config.RequestProcessor,
 	if err = agReq.SetFields(reqProcessor.RequestFields); err != nil {
 		return
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	var reqType string
 	for _, typ := range []string{
 		utils.MetaDryRun, utils.MetaAuthorize,

--- a/agents/radagent.go
+++ b/agents/radagent.go
@@ -313,7 +313,7 @@ func (ra *RadiusAgent) processRequest(req *radigo.Packet, reqProcessor *config.R
 	if err = agReq.SetFields(reqProcessor.RequestFields); err != nil {
 		return
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	var reqType string
 	for _, typ := range []string{
 		utils.MetaDryRun, utils.MetaAuthorize,

--- a/agents/sipagent.go
+++ b/agents/sipagent.go
@@ -395,7 +395,7 @@ func (sa *SIPAgent) processRequest(reqProcessor *config.RequestProcessor,
 	if err = agReq.SetFields(reqProcessor.RequestFields); err != nil {
 		return
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	var reqType string
 	for _, typ := range []string{
 		utils.MetaDryRun, utils.MetaAuthorize, /*

--- a/config/configsanity.go
+++ b/config/configsanity.go
@@ -30,6 +30,18 @@ import (
 	"github.com/cgrates/rpcclient"
 )
 
+func checkAttributeIDPath(field *FCTemplate) error {
+	if field.AttributeID == "" {
+		return nil
+	}
+	prefix, _, _ := strings.Cut(field.Path, utils.NestingSep)
+	if prefix != utils.MetaRep && prefix != utils.MetaExp {
+		return fmt.Errorf("attribute_id is only supported on %s and %s paths, got %s",
+			utils.MetaRep, utils.MetaExp, field.Path)
+	}
+	return nil
+}
+
 // CheckConfigSanity is used in cgr-engine
 func (cfg *CGRConfig) CheckConfigSanity() error {
 	return cfg.checkConfigSanity()
@@ -309,6 +321,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.DiameterAgent, err, field.Path, utils.Path)
 				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.DiameterAgent, err, field.Tag)
+				}
 				for _, val := range field.Value {
 					if err := utils.IsPathValidForExporters(val.path); err != nil {
 						return fmt.Errorf("<%s> %s for %s at %s", utils.DiameterAgent, err, val.path, utils.Values)
@@ -329,6 +344,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.DiameterAgent, err, field.Path, utils.Path)
 				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.DiameterAgent, err, field.Tag)
+				}
 				for _, val := range field.Value {
 					if err := utils.IsPathValidForExporters(val.path); err != nil {
 						return fmt.Errorf("<%s> %s for %s at %s of %s", utils.DiameterAgent, err, val.path, utils.Values, utils.RequestFieldsCfg)
@@ -346,6 +364,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				}
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.DiameterAgent, err, field.Path, utils.Path)
+				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.DiameterAgent, err, field.Tag)
 				}
 				for _, val := range field.Value {
 					if err := utils.IsPathValidForExporters(val.path); err != nil {
@@ -405,6 +426,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.RadiusAgent, err, field.Path, utils.Path)
 				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.RadiusAgent, err, field.Tag)
+				}
 				for _, val := range field.Value {
 					if err := utils.IsPathValidForExporters(val.path); err != nil {
 						return fmt.Errorf("<%s> %s for %s at %s of %s", utils.RadiusAgent, err, val.path, utils.Values, utils.RequestFieldsCfg)
@@ -420,6 +444,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				}
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.RadiusAgent, err, field.Path, utils.Path)
+				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.RadiusAgent, err, field.Tag)
 				}
 				for _, val := range field.Value {
 					if err := utils.IsPathValidForExporters(val.path); err != nil {
@@ -473,6 +500,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.DNSAgent, err, field.Path, utils.Path)
 				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.DNSAgent, err, field.Tag)
+				}
 				for _, val := range field.Value {
 					if err := utils.IsPathValidForExporters(val.path); err != nil {
 						return fmt.Errorf("<%s> %s for %s at %s of %s", utils.DNSAgent, err, val.path, utils.Values, utils.RequestFieldsCfg)
@@ -488,6 +518,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				}
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.DNSAgent, err, field.Path, utils.Path)
+				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.DNSAgent, err, field.Tag)
 				}
 				for _, val := range field.Value {
 					if err := utils.IsPathValidForExporters(val.path); err != nil {
@@ -547,6 +580,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.HTTPAgent, err, field.Path, utils.Path)
 				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.HTTPAgent, err, field.Tag)
+				}
 				for _, val := range field.Value {
 					if err := utils.IsPathValidForExporters(val.path); err != nil {
 						return fmt.Errorf("<%s> %s for %s at %s of %s", utils.HTTPAgent, err, val.path, utils.Values, utils.RequestFieldsCfg)
@@ -562,6 +598,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				}
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.HTTPAgent, err, field.Path, utils.Path)
+				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.HTTPAgent, err, field.Tag)
 				}
 				for _, val := range field.Value {
 					if err := utils.IsPathValidForExporters(val.path); err != nil {
@@ -616,6 +655,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.SIPAgent, err, field.Path, utils.Path)
 				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.SIPAgent, err, field.Tag)
+				}
 				for _, val := range field.Value {
 					if err := utils.IsPathValidForExporters(val.path); err != nil {
 						return fmt.Errorf("<%s> %s for %s at %s of %s", utils.SIPAgent, err, val.path, utils.Values, utils.RequestFieldsCfg)
@@ -631,6 +673,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				}
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.SIPAgent, err, field.Path, utils.Path)
+				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.SIPAgent, err, field.Tag)
 				}
 				for _, val := range field.Value {
 					if err := utils.IsPathValidForExporters(val.path); err != nil {
@@ -897,6 +942,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.ERs, err, field.Path, utils.Path)
 				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.ERs, err, field.Tag)
+				}
 				if field.Type == utils.MetaVariable ||
 					field.Type == utils.MetaComposed ||
 					field.Type == utils.MetaGroup ||
@@ -925,6 +973,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				}
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.ERs, err, field.Path, utils.Path)
+				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.ERs, err, field.Tag)
 				}
 				if field.Type == utils.MetaVariable ||
 					field.Type == utils.MetaComposed ||
@@ -1064,6 +1115,9 @@ func (cfg *CGRConfig) checkConfigSanity() error {
 				}
 				if err := utils.IsPathValidForExporters(field.Path); err != nil {
 					return fmt.Errorf("<%s> %s for %s at %s", utils.EEs, err, field.Path, utils.Path)
+				}
+				if err := checkAttributeIDPath(field); err != nil {
+					return fmt.Errorf("<%s> %s at %s", utils.EEs, err, field.Tag)
 				}
 				if field.Type == utils.MetaVariable ||
 					field.Type == utils.MetaComposed ||

--- a/config/configsanity_test.go
+++ b/config/configsanity_test.go
@@ -1996,3 +1996,50 @@ func TestConfigSanityERsXmlRootPath(t *testing.T) {
 		t.Errorf("expected: %s, received: %s", experr, err)
 	}
 }
+
+func TestConfigSanityAttributeIDPath(t *testing.T) {
+	cfg := NewDefaultCGRConfig()
+	cfg.sessionSCfg.Enabled = true
+	cfg.rpcConns["test"] = nil
+
+	cfg.diameterAgentCfg = &DiameterAgentCfg{
+		Enabled:       true,
+		SessionSConns: []string{"test"},
+		RequestProcessors: []*RequestProcessor{
+			{
+				ID: "attrTest",
+				RequestFields: []*FCTemplate{
+					{Tag: "XmlAttr", Path: "*cgreq.SomeField", Type: "*variable",
+						AttributeID: "myattr",
+						Value:       NewRSRParsersMustCompile("~*req.Session-Id", utils.InfieldSep)},
+				},
+				ReplyFields: []*FCTemplate{},
+			},
+		},
+	}
+
+	expected := "<DiameterAgent> attribute_id is only supported on *rep and *exp paths, got *cgreq.SomeField at XmlAttr"
+	if err := cfg.checkConfigSanity(); err == nil || err.Error() != expected {
+		t.Errorf("expected: %q, received: %q", expected, err)
+	}
+
+	// attribute_id on *rep path should pass
+	cfg.diameterAgentCfg.RequestProcessors[0].RequestFields[0].Path = "*rep.SomeField"
+	cfg.diameterAgentCfg.RequestProcessors[0].RequestFields[0].AttributeID = "myattr"
+	if err := cfg.checkConfigSanity(); err != nil {
+		t.Errorf("unexpected error for *rep path: %v", err)
+	}
+
+	// attribute_id on *exp path should pass
+	cfg.diameterAgentCfg.RequestProcessors[0].RequestFields[0].Path = "*exp.SomeField"
+	if err := cfg.checkConfigSanity(); err != nil {
+		t.Errorf("unexpected error for *exp path: %v", err)
+	}
+
+	// no attribute_id should always pass
+	cfg.diameterAgentCfg.RequestProcessors[0].RequestFields[0].Path = "*cgreq.SomeField"
+	cfg.diameterAgentCfg.RequestProcessors[0].RequestFields[0].AttributeID = ""
+	if err := cfg.checkConfigSanity(); err != nil {
+		t.Errorf("unexpected error without attribute_id: %v", err)
+	}
+}

--- a/ees/rpc.go
+++ b/ees/rpc.go
@@ -19,7 +19,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>
 package ees
 
 import (
-	"strings"
 	"sync"
 	"time"
 
@@ -100,20 +99,7 @@ func (e *RPCee) PrepareMap(mp *utils.CGREvent) (any, error) {
 }
 
 func (e *RPCee) PrepareOrderMap(oMp *utils.OrderedNavigableMap) (any, error) {
-	mP := make(map[string]any)
-	for i := oMp.GetFirstElement(); i != nil; i = i.Next() {
-		path := i.Value
-		val, _ := oMp.Field(path)
-		if val.AttributeID != utils.EmptyString {
-			continue
-		}
-		path = utils.StripTrailingIndex(path)
-		opath := strings.Join(path, utils.NestingSep)
-		if _, has := mP[opath]; !has {
-			mP[opath] = val.Data // first item which is not an attribute will become the value
-		}
-	}
-	return mP, nil
+	return oMp.AsMap(), nil
 }
 
 func (e *RPCee) parseOpts() (err error) {

--- a/ers/amqp.go
+++ b/ers/amqp.go
@@ -138,7 +138,7 @@ func (rdr *AMQPER) processMessage(msg []byte) error {
 	if err = agReq.SetFields(rdr.Config().Fields); err != nil {
 		return err
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	rdrEv := rdr.eventChan
 	if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 		rdrEv = rdr.partialEvChan

--- a/ers/amqpv1.go
+++ b/ers/amqpv1.go
@@ -180,7 +180,7 @@ func (rdr *AMQPv1ER) processMessage(msg []byte) (err error) {
 	if err = agReq.SetFields(rdr.Config().Fields); err != nil {
 		return
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	rdrEv := rdr.rdrEvents
 	if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 		rdrEv = rdr.partialEvents

--- a/ers/filecsv.go
+++ b/ers/filecsv.go
@@ -205,7 +205,7 @@ func (rdr *CSVFileER) processFile(fName string) (err error) {
 					utils.ERs, absPath, rowNr, err.Error()))
 			return
 		}
-		cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+		cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 		rdrEv := rdr.rdrEvents
 		if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 			rdrEv = rdr.partialEvents

--- a/ers/filefwv.go
+++ b/ers/filefwv.go
@@ -227,7 +227,7 @@ func (rdr *FWVFileER) processFile(fName string) (err error) {
 			return
 		}
 		rdr.offset += rdr.lineLen // increase the offset
-		cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+		cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 		rdrEv := rdr.rdrEvents
 		if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 			rdrEv = rdr.partialEvents
@@ -319,7 +319,7 @@ func (rdr *FWVFileER) processTrailer(file *os.File, rowNr, evsPosted int, absPat
 				utils.ERs, absPath, rowNr, err.Error()))
 		return err
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	rdrEv := rdr.rdrEvents
 	if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 		rdrEv = rdr.partialEvents
@@ -364,7 +364,7 @@ func (rdr *FWVFileER) createHeaderMap(record string, rowNr, evsPosted int, absPa
 				utils.ERs, absPath, rowNr, err.Error()))
 		return err
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	rdrEv := rdr.rdrEvents
 	if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 		rdrEv = rdr.partialEvents

--- a/ers/filejson.go
+++ b/ers/filejson.go
@@ -176,7 +176,7 @@ func (rdr *JSONFileER) processFile(fName string) (err error) {
 				utils.ERs, absPath, err.Error()))
 		return
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	rdrEv := rdr.rdrEvents
 	if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 		rdrEv = rdr.partialEvents

--- a/ers/filexml.go
+++ b/ers/filexml.go
@@ -200,7 +200,7 @@ func (rdr *XMLFileER) processFile(fName string) error {
 					utils.ERs, absPath, rowNr, err.Error()))
 			continue
 		}
-		cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+		cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 		rdrEv := rdr.rdrEvents
 		if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 			rdrEv = rdr.partialEvents

--- a/ers/kafka.go
+++ b/ers/kafka.go
@@ -199,7 +199,7 @@ func (rdr *KafkaER) processMessage(msg []byte) (err error) {
 	if err = agReq.SetFields(rdr.Config().Fields); err != nil {
 		return
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	rdrEv := rdr.rdrEvents
 	if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 		rdrEv = rdr.partialEvents

--- a/ers/libers.go
+++ b/ers/libers.go
@@ -97,8 +97,7 @@ func mergePartialEvents(cgrEvs []*utils.CGREvent, cfg *config.EventReaderCfg, fl
 					utils.ERs, utils.ToJSON(cgrEv), err.Error()))
 			return
 		}
-		if ev := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant,
-			utils.NestingSep, agReq.Opts); ev != nil { // add the modified fields in the event
+		if ev := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts); ev != nil { // add the modified fields in the event
 			for k, v := range ev.Event {
 				cgrEv.Event[k] = v
 			}

--- a/ers/nats.go
+++ b/ers/nats.go
@@ -208,7 +208,7 @@ func (rdr *NatsER) processMessage(msg []byte) (err error) {
 	if err = agReq.SetFields(rdr.Config().Fields); err != nil {
 		return
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	rdrEv := rdr.rdrEvents
 	if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 		rdrEv = rdr.partialEvents

--- a/ers/s3.go
+++ b/ers/s3.go
@@ -133,7 +133,7 @@ func (rdr *S3ER) processMessage(body []byte) (err error) {
 	if err = agReq.SetFields(rdr.Config().Fields); err != nil {
 		return
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	rdrEv := rdr.rdrEvents
 	if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 		rdrEv = rdr.partialEvents

--- a/ers/sql.go
+++ b/ers/sql.go
@@ -306,7 +306,7 @@ func (rdr *SQLEventReader) processMessage(ev map[string]any) (err error) {
 	if err = agReq.SetFields(rdr.Config().Fields); err != nil {
 		return
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	rdrEv := rdr.rdrEvents
 	if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 		rdrEv = rdr.partialEvents

--- a/ers/sqs.go
+++ b/ers/sqs.go
@@ -121,7 +121,7 @@ func (rdr *SQSER) processMessage(body []byte) (err error) {
 	if err = agReq.SetFields(rdr.Config().Fields); err != nil {
 		return
 	}
-	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, utils.NestingSep, agReq.Opts)
+	cgrEv := utils.NMAsCGREvent(agReq.CGRRequest, agReq.Tenant, agReq.Opts)
 	rdrEv := rdr.rdrEvents
 	if _, isPartial := cgrEv.APIOpts[utils.PartialOpt]; isPartial {
 		rdrEv = rdr.partialEvents

--- a/utils/cgrevent.go
+++ b/utils/cgrevent.go
@@ -19,7 +19,6 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>
 package utils
 
 import (
-	"strings"
 	"time"
 )
 
@@ -197,37 +196,22 @@ func GetRoutePaginatorFromOpts(ev map[string]any) (args Paginator, err error) {
 	return
 }
 
-// NMAsCGREvent builds a CGREvent considering Time as time.Now()
-// and Event as linear map[string]any with joined paths
-// treats particular case when the value of map is []*NMItem - used in agents/AgentRequest
-func NMAsCGREvent(nM *OrderedNavigableMap, tnt string, pathSep string, opts MapStorage) (cgrEv *CGREvent) {
+// NMAsCGREvent builds a CGREvent from a navigable map with nested paths.
+func NMAsCGREvent(nM *OrderedNavigableMap, tnt string, opts MapStorage) *CGREvent {
 	if nM == nil {
-		return
+		return nil
 	}
-	el := nM.GetFirstElement()
-	if el == nil {
-		return
+	ev := nM.AsMap()
+	if len(ev) == 0 {
+		return nil
 	}
-	cgrEv = &CGREvent{
+	return &CGREvent{
 		Tenant:  tnt,
 		ID:      UUIDSha1Prefix(),
 		Time:    TimePointer(time.Now()),
-		Event:   make(map[string]any),
+		Event:   ev,
 		APIOpts: opts,
 	}
-	for ; el != nil; el = el.Next() {
-		path := el.Value
-		val, _ := nM.Field(path) // this should never return error cause we get the path from the order
-		if val.AttributeID != "" {
-			continue
-		}
-		path = StripTrailingIndex(path)
-		opath := strings.Join(path, NestingSep)
-		if _, has := cgrEv.Event[opath]; !has {
-			cgrEv.Event[opath] = val.Data // first item which is not an attribute will become the value
-		}
-	}
-	return
 }
 
 // SetCloneable sets if the args should be clonned on internal connections

--- a/utils/cgrevent_test.go
+++ b/utils/cgrevent_test.go
@@ -537,15 +537,13 @@ func TestCGREventAsDataProvider(t *testing.T) {
 }
 
 func TestNMAsCGREvent(t *testing.T) {
-	if cgrEv := NMAsCGREvent(nil, "cgrates.org",
-		NestingSep, nil); cgrEv != nil {
-		t.Errorf("expecting: %+v, \nreceived: %+v", ToJSON(nil), ToJSON(cgrEv.Event))
+	if cgrEv := NMAsCGREvent(nil, "cgrates.org", nil); cgrEv != nil {
+		t.Errorf("expecting nil, received: %+v", ToJSON(cgrEv))
 	}
 
 	nM := NewOrderedNavigableMap()
-	if cgrEv := NMAsCGREvent(nM, "cgrates.org",
-		NestingSep, nil); cgrEv != nil {
-		t.Errorf("expecting: %+v, \nreceived: %+v", ToJSON(nil), ToJSON(cgrEv.Event))
+	if cgrEv := NMAsCGREvent(nM, "cgrates.org", nil); cgrEv != nil {
+		t.Errorf("expecting nil, received: %+v", ToJSON(cgrEv))
 	}
 
 	path := []string{"FirstLevel", "SecondLevel", "ThirdLevel", "Fld1"}
@@ -558,10 +556,6 @@ func TestNMAsCGREvent(t *testing.T) {
 
 	path = []string{"FirstLevel2", "SecondLevel2", "Field2"}
 	if err := nM.SetAsSlice(&FullPath{Path: strings.Join(path, NestingSep), PathSlice: path}, []*DataNode{
-		{Type: NMDataType, Value: &DataLeaf{
-			Data:        "attrVal1",
-			AttributeID: "attribute1",
-		}},
 		{Type: NMDataType, Value: &DataLeaf{
 			Data: "Value2",
 		}}}); err != nil {
@@ -576,52 +570,32 @@ func TestNMAsCGREvent(t *testing.T) {
 		t.Error(err)
 	}
 
-	path = []string{"FirstLevel2", "Field5"}
-	if err := nM.SetAsSlice(&FullPath{Path: strings.Join(path, NestingSep), PathSlice: path}, []*DataNode{
-		{Type: NMDataType, Value: &DataLeaf{
-			Data: "Value5",
-		}},
-		{Type: NMDataType, Value: &DataLeaf{
-			Data:        "attrVal5",
-			AttributeID: "attribute5",
-		}}}); err != nil {
-		t.Error(err)
-	}
-
-	path = []string{"FirstLevel2", "Field6"}
-	if err := nM.SetAsSlice(&FullPath{Path: strings.Join(path, NestingSep), PathSlice: path}, []*DataNode{
-		{Type: NMDataType, Value: &DataLeaf{
-			Data:      "Value6",
-			NewBranch: true,
-		}},
-		{Type: NMDataType, Value: &DataLeaf{
-			Data:        "attrVal6",
-			AttributeID: "attribute6",
-		}}}); err != nil {
-		t.Error(err)
-	}
-
 	path = []string{"Field4"}
 	if err := nM.SetAsSlice(&FullPath{Path: strings.Join(path, NestingSep), PathSlice: path}, []*DataNode{
 		{Type: NMDataType, Value: &DataLeaf{
 			Data: "Val4",
-		}},
-		{Type: NMDataType, Value: &DataLeaf{
-			Data:        "attrVal2",
-			AttributeID: "attribute2",
 		}}}); err != nil {
 		t.Error(err)
 	}
+
 	eEv := map[string]any{
-		"FirstLevel2.SecondLevel2.Field2":        "Value2",
-		"FirstLevel.SecondLevel.ThirdLevel.Fld1": "Val1",
-		"FirstLevel2.Field3":                     "Value3",
-		"FirstLevel2.Field5":                     "Value5",
-		"FirstLevel2.Field6":                     "Value6",
-		"Field4":                                 "Val4",
+		"FirstLevel": map[string]any{
+			"SecondLevel": map[string]any{
+				"ThirdLevel": map[string]any{
+					"Fld1": "Val1",
+				},
+			},
+		},
+		"FirstLevel2": map[string]any{
+			"SecondLevel2": map[string]any{
+				"Field2": "Value2",
+			},
+			"Field3": "Value3",
+		},
+		"Field4": "Val4",
 	}
 	if cgrEv := NMAsCGREvent(nM, "cgrates.org",
-		NestingSep, MapStorage{}); cgrEv.Tenant != "cgrates.org" ||
+		MapStorage{}); cgrEv.Tenant != "cgrates.org" ||
 		cgrEv.Time == nil ||
 		!reflect.DeepEqual(eEv, cgrEv.Event) {
 		t.Errorf("expecting: %+v, \nreceived: %+v", ToJSON(eEv), ToJSON(cgrEv.Event))


### PR DESCRIPTION
same applies to RPC exporter

2f56a9dfd3e6 added AsMap() for EES exporters but NMAsCGREvent and RPCee.PrepareOrderMap were still joining paths using dots instead of nested objects. Both are now using AsMap().

Cleaned up useless pathSep parameter from NMAsCGREvent, it was always NestingSep and never used.

The old code skipped leaves with attribute_id but attribute_id is only used for XML output on *rep and *exp paths. Instead added a configsanity check that rejects it on other prefixes at load time.