### PR TITLE
fix *group overwriting on *opts paths

### DIFF
--- a/agents/agentreq.go
+++ b/agents/agentreq.go
@@ -447,7 +447,7 @@ func (ar *AgentRequest) Append(fullPath *utils.FullPath, val *utils.DataLeaf) (e
 		_, err = ar.tmp.Append(fullPath.PathSlice[1:], val)
 		return
 	case utils.MetaOpts:
-		return ar.Opts.Set(fullPath.PathSlice[1:], val.Data)
+		return ar.Opts.Append(fullPath.PathSlice[1:], val.Data)
 	case utils.MetaUCH:
 		return engine.Cache.Set(utils.CacheUCH, fullPath.Path[5:], val.Data, nil, true, utils.NonTransactional)
 	}

--- a/agents/agentreq_test.go
+++ b/agents/agentreq_test.go
@@ -1922,6 +1922,38 @@ func TestAgReqGroupType(t *testing.T) {
 	}
 }
 
+func TestAgReqGroupOnOpts(t *testing.T) {
+	cfg := config.NewDefaultCGRConfig()
+	data, err := engine.NewInternalDB(nil, nil, true, nil, cfg.DataDbCfg().Items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dm := engine.NewDataManager(data, config.CgrConfig().CacheCfg(), nil)
+	filterS := engine.NewFilterS(cfg, nil, dm)
+	agReq := NewAgentRequest(nil, nil, nil, nil, nil, nil, "cgrates.org", "", filterS, nil)
+
+	tplFlds := []*config.FCTemplate{
+		{Tag: "Field1",
+			Path:  utils.MetaOpts + utils.NestingSep + "Field1",
+			Type:  utils.MetaGroup,
+			Value: config.NewRSRParsersMustCompile("val1", utils.InfieldSep)},
+		{Tag: "Field1",
+			Path:  utils.MetaOpts + utils.NestingSep + "Field1",
+			Type:  utils.MetaGroup,
+			Value: config.NewRSRParsersMustCompile("val2", utils.InfieldSep)},
+	}
+	for _, v := range tplFlds {
+		v.ComputePath()
+	}
+	if err := agReq.SetFields(tplFlds); err != nil {
+		t.Fatal(err)
+	}
+	exp := []any{"val1", "val2"}
+	if got := agReq.Opts["Field1"]; !reflect.DeepEqual(exp, got) {
+		t.Errorf("expected %v, got %v", exp, got)
+	}
+}
+
 func TestAgReqSetFieldsInTmp(t *testing.T) {
 	cfg := config.NewDefaultCGRConfig()
 	data, err := engine.NewInternalDB(nil, nil, true, nil, cfg.DataDbCfg().Items)

--- a/engine/exportrequest.go
+++ b/engine/exportrequest.go
@@ -215,7 +215,7 @@ func (eeR *ExportRequest) Append(fullPath *utils.FullPath, val *utils.DataLeaf) 
 	case utils.MetaUCH:
 		return Cache.Set(utils.CacheUCH, fullPath.Path[5:], val.Data, nil, true, utils.NonTransactional)
 	case utils.MetaOpts:
-		return eeR.inData[utils.MetaOpts].Set(fullPath.PathSlice[1:], val.Data)
+		return eeR.inData[utils.MetaOpts].(utils.MapStorage).Append(fullPath.PathSlice[1:], val.Data)
 	default:
 		oNM, has := eeR.ExpData[prfx]
 		if !has {

--- a/engine/exportrequest_test.go
+++ b/engine/exportrequest_test.go
@@ -491,6 +491,16 @@ func TestExportRequestAppend(t *testing.T) {
 	if err = eeR.Append(fullPath, val); err != nil {
 		t.Error(err)
 	}
+	if err = eeR.Append(fullPath, &utils.DataLeaf{Data: "value2"}); err != nil {
+		t.Error(err)
+	}
+	optsMS := eeR.inData[utils.MetaOpts].(utils.MapStorage)
+	expSlice := []any{"value1", "value2"}
+	if got, err := optsMS.FieldAsInterface(fullPath.PathSlice[1:]); err != nil {
+		t.Error(err)
+	} else if !reflect.DeepEqual(expSlice, got) {
+		t.Errorf("expected %v, got %v", expSlice, got)
+	}
 	fullPath.PathSlice[0] = "default"
 	if err = eeR.Append(fullPath, val); err != nil {
 		t.Error(err)

--- a/utils/mapstorage.go
+++ b/utils/mapstorage.go
@@ -205,6 +205,42 @@ func (ms MapStorage) Set(fldPath []string, val any) (err error) {
 
 }
 
+// Append appends val to a []any slice at the given path.
+// If the key is missing, it creates []any{val}.
+// If the key holds a []any, it appends to it.
+// If the key holds any other value, it promotes to []any{existing, val}.
+func (ms MapStorage) Append(fldPath []string, val any) error {
+	if len(fldPath) == 0 {
+		return ErrWrongPath
+	}
+	if len(fldPath) == 1 {
+		existing, has := ms[fldPath[0]]
+		if !has {
+			ms[fldPath[0]] = []any{val}
+			return nil
+		}
+		if sl, ok := existing.([]any); ok {
+			ms[fldPath[0]] = append(sl, val)
+			return nil
+		}
+		ms[fldPath[0]] = []any{existing, val}
+		return nil
+	}
+	if _, has := ms[fldPath[0]]; !has {
+		nMap := MapStorage{}
+		ms[fldPath[0]] = nMap
+		return nMap.Append(fldPath[1:], val)
+	}
+	switch dp := ms[fldPath[0]].(type) {
+	case MapStorage:
+		return dp.Append(fldPath[1:], val)
+	case map[string]any:
+		return MapStorage(dp).Append(fldPath[1:], val)
+	default:
+		return ErrWrongPath
+	}
+}
+
 // GetKeys returns all the keys from map
 func (ms MapStorage) GetKeys(nested bool, nestedLimit int, prefix string) (keys []string) {
 	if prefix != EmptyString {

--- a/utils/mapstorage_test.go
+++ b/utils/mapstorage_test.go
@@ -1025,3 +1025,87 @@ func TestNewSecureMapStorage(t *testing.T) {
 		t.Error("should receive new secure map")
 	}
 }
+
+func TestMapStorageAppend(t *testing.T) {
+	t.Run("empty path", func(t *testing.T) {
+		ms := MapStorage{}
+		if err := ms.Append(nil, "val"); err != ErrWrongPath {
+			t.Errorf("expected ErrWrongPath, got %v", err)
+		}
+	})
+
+	t.Run("missing key", func(t *testing.T) {
+		ms := MapStorage{}
+		if err := ms.Append([]string{"key"}, "val1"); err != nil {
+			t.Fatal(err)
+		}
+		exp := []any{"val1"}
+		if got := ms["key"]; !reflect.DeepEqual(exp, got) {
+			t.Errorf("expected %v, got %v", exp, got)
+		}
+	})
+
+	t.Run("append twice", func(t *testing.T) {
+		ms := MapStorage{}
+		if err := ms.Append([]string{"key"}, "val1"); err != nil {
+			t.Fatal(err)
+		}
+		if err := ms.Append([]string{"key"}, "val2"); err != nil {
+			t.Fatal(err)
+		}
+		exp := []any{"val1", "val2"}
+		if got := ms["key"]; !reflect.DeepEqual(exp, got) {
+			t.Errorf("expected %v, got %v", exp, got)
+		}
+	})
+
+	t.Run("promote scalar", func(t *testing.T) {
+		ms := MapStorage{"key": "existing"}
+		if err := ms.Append([]string{"key"}, "new"); err != nil {
+			t.Fatal(err)
+		}
+		exp := []any{"existing", "new"}
+		if got := ms["key"]; !reflect.DeepEqual(exp, got) {
+			t.Errorf("expected %v, got %v", exp, got)
+		}
+	})
+
+	t.Run("nested path", func(t *testing.T) {
+		ms := MapStorage{}
+		if err := ms.Append([]string{"a", "b"}, "val1"); err != nil {
+			t.Fatal(err)
+		}
+		if err := ms.Append([]string{"a", "b"}, "val2"); err != nil {
+			t.Fatal(err)
+		}
+		inner, ok := ms["a"].(MapStorage)
+		if !ok {
+			t.Fatalf("expected MapStorage at key 'a', got %T", ms["a"])
+		}
+		exp := []any{"val1", "val2"}
+		if got := inner["b"]; !reflect.DeepEqual(exp, got) {
+			t.Errorf("expected %v, got %v", exp, got)
+		}
+	})
+
+	t.Run("nested into map[string]any", func(t *testing.T) {
+		ms := MapStorage{
+			"a": map[string]any{"existing": "data"},
+		}
+		if err := ms.Append([]string{"a", "key"}, "val1"); err != nil {
+			t.Fatal(err)
+		}
+		inner := ms["a"].(map[string]any)
+		exp := []any{"val1"}
+		if got := inner["key"]; !reflect.DeepEqual(exp, got) {
+			t.Errorf("expected %v, got %v", exp, got)
+		}
+	})
+
+	t.Run("wrong path type", func(t *testing.T) {
+		ms := MapStorage{"a": 42}
+		if err := ms.Append([]string{"a", "b"}, "val"); err != ErrWrongPath {
+			t.Errorf("expected ErrWrongPath, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
AgentRequest.Append and ExportRequest.Append were calling Set on *opts paths, so *group just overwrote instead of building a slice. Added MapStorage.Append to handle it.