### PR TITLE
pass ExtraFields in refundSession and roundCost

### DIFF
--- a/general_tests/dsp_multi_chain_it_test.go
+++ b/general_tests/dsp_multi_chain_it_test.go
@@ -541,6 +541,7 @@ func TestDispatcherMultiChain(t *testing.T) {
 					{"tag": "Destination", "path": "*cgreq.Destination", "type": "*variable", "value": "~*req.destination"},
 					{"tag": "SetupTime", "path": "*cgreq.SetupTime", "type": "*constant", "value": "*now"},
 					{"tag": "AnswerTime", "path": "*cgreq.AnswerTime", "type": "*constant", "value": "*now"},
+					{"tag": "Usage", "path": "*cgreq.Usage", "type": "*variable", "value": "~*req.usage", "filters": ["*notempty:~*req.usage:"]},
 					{"tag": "Agent", "path": "*cgreq.Agent", "type": "*constant", "value": "ha1"},
 					{"tag": "RouteID", "path": "*cgreq.*route_id", "type": "*variable", "value": "~*req.account"}
 				],
@@ -673,6 +674,7 @@ func TestDispatcherMultiChain(t *testing.T) {
 					{"tag": "Destination", "path": "*cgreq.Destination", "type": "*variable", "value": "~*req.destination"},
 					{"tag": "SetupTime", "path": "*cgreq.SetupTime", "type": "*constant", "value": "*now"},
 					{"tag": "AnswerTime", "path": "*cgreq.AnswerTime", "type": "*constant", "value": "*now"},
+					{"tag": "Usage", "path": "*cgreq.Usage", "type": "*variable", "value": "~*req.usage", "filters": ["*notempty:~*req.usage:"]},
 					{"tag": "Agent", "path": "*cgreq.Agent", "type": "*constant", "value": "ha2"},
 					{"tag": "RouteID", "path": "*cgreq.*route_id", "type": "*variable", "value": "~*req.account"}
 				],
@@ -688,11 +690,14 @@ func TestDispatcherMultiChain(t *testing.T) {
 	// Tariff plan files with dispatcher profiles for both DSP1 and DSP2
 	tpFiles := map[string]string{
 		utils.DestinationRatesCsv: `#Id,DestinationId,RatesTag,RoundingMethod,RoundingDecimals,MaxCost,MaxCostStrategy
-DR_ANY,*any,RT_ANY,*up,0,0,`,
+DR_ANY,*any,RT_ANY,*up,0,0,
+DR_ROUND,*any,RT_ROUND,*up,0,0,`,
 		utils.RatesCsv: `#Id,ConnectFee,Rate,RateUnit,RateIncrement,GroupIntervalStart
-RT_ANY,0,1,1s,1s,0s`,
+RT_ANY,0,1,1s,1s,0s
+RT_ROUND,0,1,2s,1s,0s`,
 		utils.RatingPlansCsv: `#Id,DestinationRatesId,TimingTag,Weight
-RP_ANY,DR_ANY,*any,10`,
+RP_ANY,DR_ANY,*any,10
+RP_ROUND,DR_ROUND,*any,10`,
 		utils.RatingProfilesCsv: `#Tenant,Category,Subject,ActivationTime,RatingPlanId,RatesFallbackSubject
 cgrates.org,call,1001,,RP_ANY,
 cgrates.org,call,1002,,RP_ANY,
@@ -703,7 +708,8 @@ cgrates.org,call,2001,,RP_ANY,
 cgrates.org,call,2002,,RP_ANY,
 cgrates.org,call,2003,,RP_ANY,
 cgrates.org,call,2004,,RP_ANY,
-cgrates.org,call,2005,,RP_ANY,`,
+cgrates.org,call,2005,,RP_ANY,
+cgrates.org,call,3001,,RP_ROUND,`,
 		utils.ChargersCsv: `#Tenant,ID,FilterIDs,ActivationInterval,RunID,AttributeIDs,Weight
 cgrates.org,DEFAULT,,,*default,*none,0`,
 		utils.FiltersCsv: `#Tenant,ID,Type,Path,Values,ActivationInterval
@@ -968,4 +974,22 @@ cgrates.org,DSP2_RALS,,,,,,RALS4,,10,,,`,
 	checkBalance(t, "2003", 72)
 	checkBalance(t, "2004", 72)
 	checkBalance(t, "2005", 72)
+
+	// Refund through dispatcher: init 10s, terminate with 7s.
+	setBalance(t, "1001", 100)
+	sessionID := fmt.Sprintf("session_1001_%d", sessionNo.Add(1))
+	sendRequest(t, 2080, "auth", sessionID, "1001", "1099", "10s")
+	sendRequest(t, 2080, "init", sessionID, "1001", "1099", "10s")
+	sendRequest(t, 2080, "terminate", sessionID, "1001", "1099", "7s")
+	checkBalance(t, "1001", 93) // 100 - 10 + 3 = 93
+
+	// Rounding through dispatcher: RT_ROUND is 1 credit per 2s.
+	// 5s costs 2.5, rounded *up to 3. RefundRounding charges the extra 0.5 to
+	// match the rounded cost.
+	setBalance(t, "3001", 100)
+	sessionID = fmt.Sprintf("session_3001_%d", sessionNo.Add(1))
+	sendRequest(t, 2080, "auth", sessionID, "3001", "1099", "5s")
+	sendRequest(t, 2080, "init", sessionID, "3001", "1099", "5s")
+	sendRequest(t, 2080, "terminate", sessionID, "3001", "1099", "")
+	checkBalance(t, "3001", 97) // 100 - 3 = 97
 }

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -588,6 +588,7 @@ func (sS *SessionS) refundSession(s *Session, sRunIdx int, rUsage time.Duration)
 		Account:     sr.CD.Account,
 		Destination: sr.CD.Destination,
 		ToR:         utils.FirstNonEmpty(sr.CD.ToR, utils.VOICE),
+		ExtraFields: sr.CD.ExtraFields,
 		Increments:  incrmts,
 	}
 	var acnt engine.Account
@@ -663,11 +664,15 @@ func (sS *SessionS) roundCost(s *Session, sRunIdx int) (err error) {
 		cd := cc.CreateCallDescriptor()
 		cd.CgrID = s.CGRID
 		cd.RunID = runID
+		cd.ExtraFields = sr.CD.ExtraFields
 		cd.Increments = roundIncrements
 		response := new(engine.Account)
 		if err = sS.connMgr.Call(sS.cfg.SessionSCfg().RALsConns, nil,
 			utils.ResponderRefundRounding,
-			&engine.CallDescriptorWithArgDispatcher{CallDescriptor: cd},
+			&engine.CallDescriptorWithArgDispatcher{
+				CallDescriptor: cd,
+				ArgDispatcher:  s.ArgDispatcher,
+			},
 			response); err != nil {
 			return
 		}


### PR DESCRIPTION
similar to fabdf9702. Both functions build CallDescriptors that go through the dispatcher but don't include ExtraFields, so profile matching fails. roundCost also missed ArgDispatcher.