### PR TITLE
ansible: clone cgrates directly in deb_packages

### DIFF
--- a/data/ansible/deb_packages/main.yaml
+++ b/data/ansible/deb_packages/main.yaml
@@ -3,6 +3,8 @@
   vars:
     rootUser: root
     nginx_server_name: apt.cgrates.org
+    cgrates_dir: "/home/{{ user }}/go/src/github.com/cgrates/cgrates"
+    cgrates_branch: master
 
     dependencies:
       - build-essential
@@ -148,13 +150,13 @@
 
     ###########################################################################################################################
     ###########################################################################################################################
-    - name: Set up cgrates
-      ansible.builtin.import_role:
-        name: ../../roles/cgrates
-      vars:
-        cgrates_bin_path: ""
-        cgrates_dbs: []
-        cgrates_dependencies: []
+    - name: Clone cgrates source
+      ansible.builtin.git:
+        repo: https://github.com/cgrates/cgrates.git
+        dest: "{{ cgrates_dir }}"
+        version: "{{ cgrates_branch }}"
+        update: true
+        force: true
 
     - name: Remove leftover dependencies/ from a prior failed deb build
       ansible.builtin.file:


### PR DESCRIPTION
since everything is done in chroots, there is no need to build the binaries