### PR TITLE
ansible: only scp debs to pkg server in deb_packages

### DIFF
--- a/data/ansible/deb_packages/main.yaml
+++ b/data/ansible/deb_packages/main.yaml
@@ -243,9 +243,16 @@
             - not (skip_reprepro | default(false))
             - cgrates_branch == 'master' or git_tag_result.stdout_lines | length > 0
 
-        - name: Copy the file to PKG server
-          ansible.builtin.command: "scp {{ reprepro_basedir }}/incoming/{{ item.path | basename }} {{ pkgAddr }}:/tmp/"
-          with_items: "{{ package_files.files }}"
+        - name: Find debs for PKG server
+          ansible.builtin.find:
+            paths: "{{ reprepro_basedir }}/incoming"
+            patterns: "cgrates_*~deb*u1_amd64.deb"
+            file_type: file
+          register: pkg_debs
+
+        - name: Copy debs to PKG server
+          ansible.builtin.command: "scp {{ item.path }} {{ pkgAddr }}:/tmp/"
+          with_items: "{{ pkg_debs.files }}"
 
       rescue:
         - name: Find all files in incoming directory


### PR DESCRIPTION
the pkg play only moves the main debs out of /tmp/, the rest just kept gathering there

(cherry picked from commit 53ced11d42b33179f042b01966e8b1b0705ff294)