### PR TITLE
sessions: query sync clients in parallel

### DIFF
--- a/general_tests/sync_sessions_it_test.go
+++ b/general_tests/sync_sessions_it_test.go
@@ -1,0 +1,175 @@
+//go:build integration
+
+/*
+Real-time Online/Offline Charging System (OCS) for Telecom & ISP environments
+Copyright (C) ITsysCOM GmbH
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>
+*/
+
+package general_tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cenkalti/rpc2"
+
+	"github.com/cgrates/cgrates/engine"
+	"github.com/cgrates/cgrates/sessions"
+	"github.com/cgrates/cgrates/utils"
+)
+
+func TestSyncSessions(t *testing.T) {
+	cfgJSON := `{
+"data_db": {
+	"db_type": "*internal"
+},
+"stor_db": {
+	"db_type": "*internal"
+},
+"general": {
+	"reply_timeout": "1s"
+},
+"chargers": {
+	"enabled": true
+},
+"sessions": {
+	"enabled": true,
+	"channel_sync_interval": "0",
+	"chargers_conns": ["*internal"]
+},
+"apiers": {
+	"enabled": true
+}
+}`
+	ng := TestEnvironment{
+		ConfigJSON: cfgJSON,
+	}
+	client, cfg := ng.Setup(t, 0)
+	replyTimeout := cfg.GeneralCfg().ReplyTimeout
+
+	var reply string
+	if err := client.Call(utils.APIerSv1SetChargerProfile, &engine.ChargerProfile{
+		Tenant:       "cgrates.org",
+		ID:           "DEFAULT",
+		RunID:        utils.MetaDefault,
+		AttributeIDs: []string{utils.META_NONE},
+		Weight:       10,
+	}, &reply); err != nil {
+		t.Fatalf("SetChargerProfile: %v", err)
+	}
+
+	disconnectCh := make(chan *utils.AttrDisconnectSession, 1)
+	type activeSessionIDsHandler func(*rpc2.Client, *string, *[]*sessions.SessionID) error
+	newClient := func(name string, getActive activeSessionIDsHandler) *rpc2.Client {
+		t.Helper()
+		handlers := map[string]any{
+			utils.SessionSv1GetActiveSessionIDs: getActive,
+			utils.SessionSv1DisconnectSession: func(_ *rpc2.Client, args *utils.AttrDisconnectSession, reply *string) error {
+				disconnectCh <- args
+				*reply = utils.OK
+				return nil
+			},
+		}
+		biJSONClient, err := utils.NewBiJSONrpcClient(cfg.SessionSCfg().ListenBijson, handlers)
+		if err != nil {
+			t.Fatalf("BiJSON dial %s: %v", name, err)
+		}
+		t.Cleanup(func() { biJSONClient.Close() })
+		return biJSONClient
+	}
+
+	keepClient := newClient("keep", func(_ *rpc2.Client, _ *string, reply *[]*sessions.SessionID) error {
+		*reply = []*sessions.SessionID{{
+			OriginID:   "session-keep",
+			OriginHost: "127.0.0.1",
+		}}
+		return nil
+	})
+	timeoutHandler := func(_ *rpc2.Client, _ *string, _ *[]*sessions.SessionID) error {
+		time.Sleep(2 * replyTimeout)
+		return nil
+	}
+	timeoutClient := newClient("timeout", timeoutHandler)
+	newClient("timeout-extra", timeoutHandler)
+
+	initSession := func(biJSONClient *rpc2.Client, originID string) {
+		t.Helper()
+		initArgs := &sessions.V1InitSessionArgs{
+			InitSession: true,
+			CGREvent: &utils.CGREvent{
+				Tenant: "cgrates.org",
+				ID:     originID,
+				Event: map[string]any{
+					utils.OriginID:    originID,
+					utils.OriginHost:  "127.0.0.1",
+					utils.Account:     "1001",
+					utils.Subject:     "1001",
+					utils.Destination: "1002",
+					utils.Category:    "call",
+					utils.Tenant:      "cgrates.org",
+					utils.RequestType: utils.META_NONE,
+					utils.SetupTime:   time.Now(),
+					utils.AnswerTime:  time.Now(),
+					utils.Usage:       time.Hour,
+				},
+			},
+		}
+		var initReply sessions.V1InitSessionReply
+		if err := biJSONClient.Call(utils.SessionSv1InitiateSession, initArgs, &initReply); err != nil {
+			t.Fatalf("InitiateSession %s: %v", originID, err)
+		}
+	}
+	initSession(keepClient, "session-keep")
+	initSession(timeoutClient, "session-timeout")
+
+	var activeSessions []*sessions.ExternalSession
+	if err := client.Call(utils.SessionSv1GetActiveSessions, &utils.SessionFilter{}, &activeSessions); err != nil {
+		t.Fatalf("GetActiveSessions: %v", err)
+	}
+	if len(activeSessions) != 2 {
+		t.Fatalf("want 2 active sessions, got %d", len(activeSessions))
+	}
+
+	start := time.Now()
+	if err := client.Call(utils.SessionSv1SyncSessions, "", &reply); err != nil {
+		t.Fatalf("SyncSessions: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > replyTimeout+replyTimeout/2 {
+		t.Fatalf("SyncSessions took %v, want parallel timeout around %v", elapsed, replyTimeout)
+	}
+
+	select {
+	case disconnect := <-disconnectCh:
+		originID, _ := disconnect.EventStart[utils.OriginID].(string)
+		if originID != "session-timeout" {
+			t.Fatalf("disconnect OriginID = %q, want session-timeout", originID)
+		}
+	case <-time.After(replyTimeout):
+		t.Fatal("expected force-disconnect callback")
+	}
+
+	activeSessions = nil
+	if err := client.Call(utils.SessionSv1GetActiveSessions, &utils.SessionFilter{}, &activeSessions); err != nil {
+		t.Fatalf("GetActiveSessions after sync: %v", err)
+	}
+	if len(activeSessions) != 1 {
+		t.Fatalf("want 1 active session after sync, got %d", len(activeSessions))
+	}
+	activeOriginID := activeSessions[0].OriginID
+	if activeOriginID != "session-keep" {
+		t.Fatalf("active OriginID = %q, want session-keep", activeOriginID)
+	}
+}

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -1264,57 +1264,58 @@ func (sS *SessionS) getRelocateSession(cgrID string, initOriginID,
 // any client.
 func (sS *SessionS) syncSessions() {
 	sS.aSsMux.RLock()
-	asCount := len(sS.aSessions)
+	activeCGRIDs := make([]string, 0, len(sS.aSessions))
+	for cgrID := range sS.aSessions {
+		activeCGRIDs = append(activeCGRIDs, cgrID)
+	}
 	sS.aSsMux.RUnlock()
-	if asCount == 0 { // no need to sync the sessions if none is active
+	if len(activeCGRIDs) == 0 {
 		return
 	}
-	if len(sS.biJClients()) == 0 {
+
+	biJClnts := sS.biJClients()
+	if len(biJClnts) == 0 {
 		utils.Logger.Notice(fmt.Sprintf(
 			"<%s> no bidirectional clients connected - proceeding to terminate %d active sessions",
-			utils.SessionS, asCount))
+			utils.SessionS, len(activeCGRIDs)))
 	}
-	queriedCGRIDs := engine.NewSafEvent(nil)
-	var err error
-	for _, clnt := range sS.biJClients() {
-		errC := make(chan error)
-		go func() {
-			var queriedSessionIDs []*SessionID
-			if err := clnt.conn.Call(context.TODO(), utils.SessionSv1GetActiveSessionIDs,
-				utils.EmptyString, &queriedSessionIDs); err != nil {
-				errC <- err
-				return
-			}
-			for _, sessionID := range queriedSessionIDs {
-				queriedCGRIDs.Set(sessionID.CGRID(), struct{}{})
-			}
-			errC <- nil
-		}()
-		select {
-		case err = <-errC:
-			if err != nil {
+	results := make(chan []*SessionID, len(biJClnts))
+	timeout := sS.cfg.GeneralCfg().ReplyTimeout
+	for _, clnt := range biJClnts {
+		go func(clnt *biJClient) {
+			ctx, cancel := context.WithTimeout(context.TODO(), timeout)
+			defer cancel()
+			var sessionIDs []*SessionID
+			if err := clnt.conn.Call(ctx, utils.SessionSv1GetActiveSessionIDs,
+				"", &sessionIDs); err != nil {
 				utils.Logger.Warning(fmt.Sprintf(
-					"<%s> failed to query session IDs: %v", utils.SessionS, err))
+					"<%s> failed to retrieve active session IDs: %v", utils.SessionS, err))
+				sessionIDs = nil
 			}
-		case <-time.After(sS.cfg.GeneralCfg().ReplyTimeout):
-			utils.Logger.Warning(fmt.Sprintf(
-				"<%s> timeout while querying session IDs", utils.SessionS))
+			results <- sessionIDs
+		}(clnt)
+	}
+	queriedCGRIDs := utils.StringSet{}
+	for range biJClnts {
+		for _, sessionID := range <-results {
+			queriedCGRIDs.Add(sessionID.CGRID())
 		}
 	}
-	var toBeRemoved []string
-	sS.aSsMux.RLock()
-	for cgrid := range sS.aSessions {
-		if !queriedCGRIDs.HasField(cgrid) {
-			toBeRemoved = append(toBeRemoved, cgrid)
+
+	var missingCGRIDs []string
+	for _, cgrID := range activeCGRIDs {
+		if !queriedCGRIDs.Has(cgrID) {
+			missingCGRIDs = append(missingCGRIDs, cgrID)
 		}
 	}
-	sS.aSsMux.RUnlock()
-	for _, cgrID := range toBeRemoved {
+	for _, cgrID := range missingCGRIDs {
 		sess := sS.getSessions(cgrID, false)
 		if len(sess) == 0 {
 			continue
 		}
-		sess[0].Lock() // protect forceSTerminate as it is not thread safe for the session
+
+		// forceSTerminate is not thread-safe for the session.
+		sess[0].Lock()
 		if err := sS.forceSTerminate(sess[0], 0, nil, nil); err != nil {
 			utils.Logger.Warning(fmt.Sprintf(
 				"<%s> failed to force-terminate session <%s>: %v", utils.SessionS, cgrID, err))

--- a/sessions/sessions_test.go
+++ b/sessions/sessions_test.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/cgrates/birpc"
@@ -2346,6 +2347,16 @@ type clMock func(_ *context.Context, _ string, _ any, _ any) error
 func (c clMock) Call(ctx *context.Context, m string, a any, r any) error {
 	return c(ctx, m, a, r)
 }
+
+// like clMock, but a struct so it can be a map key.
+type biJClientMock struct {
+	call func(ctx *context.Context, method string, args any, reply any) error
+}
+
+func (c *biJClientMock) Call(ctx *context.Context, method string, args any, reply any) error {
+	return c.call(ctx, method, args, reply)
+}
+
 func TestInitSession(t *testing.T) {
 	cfg, _ := config.NewDefaultCGRConfig()
 	cfg.SessionSCfg().ChargerSConns = []string{utils.ConcatenatedKey(utils.MetaInternal, utils.MetaChargers)}
@@ -3042,6 +3053,65 @@ func TestSyncSessionsSync(t *testing.T) {
 	}
 
 	engine.Cache = tmp
+}
+
+func TestSyncSessionsClientTimeoutsRunInParallel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cfg, err := config.NewDefaultCGRConfig()
+		if err != nil {
+			t.Fatal(err)
+		}
+		cfg.GeneralCfg().ReplyTimeout = 5 * time.Second
+		sS := NewSessionS(cfg, nil, nil)
+		sessionID := &SessionID{
+			OriginID:   "session-keep",
+			OriginHost: "127.0.0.1",
+		}
+		cgrID := sessionID.CGRID()
+		sS.aSessions[cgrID] = &Session{CGRID: cgrID}
+
+		const clientCount = 3
+		calls := make(chan struct{}, clientCount)
+		newClient := func(call func(*context.Context, *[]*SessionID) error) *biJClientMock {
+			t.Helper()
+			return &biJClientMock{
+				call: func(ctx *context.Context, method string, _ any, reply any) error {
+					if method != utils.SessionSv1GetActiveSessionIDs {
+						t.Errorf("method = %s, want %s", method, utils.SessionSv1GetActiveSessionIDs)
+					}
+					sessionIDs, ok := reply.(*[]*SessionID)
+					if !ok {
+						t.Errorf("reply type = %T, want *[]*SessionID", reply)
+						return nil
+					}
+					calls <- struct{}{}
+					return call(ctx, sessionIDs)
+				},
+			}
+		}
+		sS.OnBiJSONConnect(newClient(func(_ *context.Context, reply *[]*SessionID) error {
+			*reply = []*SessionID{sessionID}
+			return nil
+		}))
+		timeoutCall := func(ctx *context.Context, _ *[]*SessionID) error {
+			<-ctx.Done()
+			return ctx.Err()
+		}
+		sS.OnBiJSONConnect(newClient(timeoutCall))
+		sS.OnBiJSONConnect(newClient(timeoutCall))
+
+		start := time.Now()
+		sS.syncSessions()
+		if elapsed := time.Since(start); elapsed != cfg.GeneralCfg().ReplyTimeout {
+			t.Fatalf("syncSessions took %v, want %v", elapsed, cfg.GeneralCfg().ReplyTimeout)
+		}
+		if got := len(calls); got != clientCount {
+			t.Fatalf("called %d clients, want %d", got, clientCount)
+		}
+		if sessions := sS.getSessions(cgrID, false); len(sessions) != 1 {
+			t.Fatalf("kept sessions = %d, want 1", len(sessions))
+		}
+	})
 }
 
 func TestBiRPCv1GetPassiveSessionsCount(t *testing.T) {


### PR DESCRIPTION
Query bidirectional clients concurrently and give each request its own context timeout. Collect replies through a buffered channel and wait for all queries before deciding which active sessions are missing.

Clients that time out or return an error are treated as reporting no active sessions.