### PR TITLE
kamagent: respect reply_timeout when listing dialogs

### DIFF
--- a/agents/kamagent.go
+++ b/agents/kamagent.go
@@ -44,24 +44,23 @@ var (
 	kamProcessCDRRegex     = regexp.MustCompile(CGR_PROCESS_CDR)
 )
 
-func NewKamailioAgent(kaCfg *config.KamAgentCfg,
-	connMgr *engine.ConnManager, timezone string) (ka *KamailioAgent) {
-	ka = &KamailioAgent{
-		cfg:              kaCfg,
-		connMgr:          connMgr,
-		timezone:         timezone,
-		conns:            make([]*kamevapi.KamEvapi, len(kaCfg.EvapiConns)),
-		activeSessionIDs: make(chan []*sessions.SessionID),
+func NewKamailioAgent(kaCfg *config.KamAgentCfg, connMgr *engine.ConnManager,
+	timezone string) *KamailioAgent {
+	return &KamailioAgent{
+		cfg:      kaCfg,
+		connMgr:  connMgr,
+		timezone: timezone,
+		conns:    make([]*kamevapi.KamEvapi, len(kaCfg.EvapiConns)),
+		replyCh:  make(chan []*sessions.SessionID, len(kaCfg.EvapiConns)),
 	}
-	return
 }
 
 type KamailioAgent struct {
-	cfg              *config.KamAgentCfg
-	connMgr          *engine.ConnManager
-	timezone         string
-	conns            []*kamevapi.KamEvapi
-	activeSessionIDs chan []*sessions.SessionID
+	cfg      *config.KamAgentCfg
+	connMgr  *engine.ConnManager
+	timezone string
+	conns    []*kamevapi.KamEvapi
+	replyCh  chan []*sessions.SessionID
 }
 
 func (self *KamailioAgent) Connect() (err error) {
@@ -261,7 +260,12 @@ func (ka *KamailioAgent) onDlgList(evData []byte, connIdx int) {
 			OriginID:   dlgInfo.CallId + ";" + dlgInfo.Caller.Tag,
 		})
 	}
-	ka.activeSessionIDs <- sIDs
+	// kamevapi runs onDlgList in its own goroutine, so a blocking send
+	// would leak it.
+	select {
+	case ka.replyCh <- sIDs:
+	default:
+	}
 }
 
 func (ka *KamailioAgent) onCgrProcessMessage(evData []byte, connIdx int) {
@@ -402,28 +406,43 @@ func (ka *KamailioAgent) V1DisconnectSession(args utils.AttrDisconnectSession, r
 }
 
 // V1GetActiveSessionIDs returns a list of CGRIDs based on active sessions from agent
-func (ka *KamailioAgent) V1GetActiveSessionIDs(ignParam string, sessionIDs *[]*sessions.SessionID) (err error) {
-	for _, evapi := range ka.conns {
-		kamEv, _ := json.Marshal(map[string]string{utils.Event: CGR_DLG_LIST})
-		if err = evapi.Send(string(kamEv)); err != nil {
-			utils.Logger.Err(fmt.Sprintf("<%s> failed sending event, error %s",
-				utils.KamailioAgent, err.Error()))
-			return
-		}
+func (ka *KamailioAgent) V1GetActiveSessionIDs(ignParam string, sessionIDs *[]*sessions.SessionID) error {
+	// drop stale replies from a previous sync
+	for len(ka.replyCh) > 0 {
+		<-ka.replyCh
 	}
-	for range ka.conns {
+	kamEv, _ := json.Marshal(map[string]string{utils.Event: CGR_DLG_LIST})
+	var sent int
+	for i, evapi := range ka.conns {
+		if err := evapi.Send(string(kamEv)); err != nil {
+			utils.Logger.Err(fmt.Sprintf("<%s> failed sending event to connIdx<%v>: %v",
+				utils.KamailioAgent, i, err))
+			continue
+		}
+		sent++
+	}
+	if sent == 0 {
+		return errors.New("failed sending dialog list to any connection")
+	}
+	tm := time.NewTimer(config.CgrConfig().GeneralCfg().ReplyTimeout)
+	defer tm.Stop()
+	for range sent {
 		select {
-		case sIDs := <-ka.activeSessionIDs:
+		case sIDs := <-ka.replyCh:
 			*sessionIDs = append(*sessionIDs, sIDs...)
-		case <-time.After(5 * time.Second):
+		case <-tm.C:
 			return errors.New("timeout executing dialog list")
 		}
 	}
-	return
+	if len(*sessionIDs) == 0 {
+		return utils.ErrNoActiveSession
+	}
+	return nil
 }
 
 // Reload recreates the connection buffers
 // only used on reload
 func (ka *KamailioAgent) Reload() {
 	ka.conns = make([]*kamevapi.KamEvapi, len(ka.cfg.EvapiConns))
+	ka.replyCh = make(chan []*sessions.SessionID, len(ka.cfg.EvapiConns))
 }

--- a/agents/kamagent_bench_test.go
+++ b/agents/kamagent_bench_test.go
@@ -1,0 +1,77 @@
+/*
+Real-time Online/Offline Charging System (OCS) for Telecom & ISP environments
+Copyright (C) ITsysCOM GmbH
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>
+*/
+
+package agents
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cgrates/cgrates/sessions"
+)
+
+// buildDlgListResponse builds a CGR_DLG_LIST reply with n realistic dialogs.
+func buildDlgListResponse(n int) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(`{"Event":"CGR_DLG_LIST","Jsonrpl_body":{"jsonrpc":"2.0","id":1,"result":[`)
+	for i := range n {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		fmt.Fprintf(&buf,
+			`{"h_entry":%d,"h_id":%d,"ref_count":1,"timestart":%d,"timeout":%d,`+
+				`"state":4,"lifetime":3600,"init_ts":%d,"dflags":64,"iflags":0,`+
+				`"sflags":0,"toroute_index":0,"toroute_name":"",`+
+				`"call-id":"call-bench-%d-1234567890abcdef@bench.local",`+
+				`"from_uri":"sip:caller-bench-%d@bench.local",`+
+				`"to_uri":"sip:callee-bench-%d@bench.local",`+
+				`"caller":{"tag":"ftag-bench-%d-abcdef0123","contact":"<sip:caller-bench-%d@10.0.0.1:5060>","cseq":"1","route_set":"","socket":"udp:10.0.0.1:5060","bind_addr":"udp:10.0.0.1:5060","sdp":""},`+
+				`"callee":{"tag":"ttag-bench-%d-abcdef0123","contact":"<sip:callee-bench-%d@10.0.0.2:5060>","cseq":"1","route_set":"","socket":"udp:10.0.0.2:5060","bind_addr":"udp:10.0.0.2:5060","sdp":""},`+
+				`"profiles":[],"variables":[]}`,
+			i%4096, i, 1715000000+i, 1715003600+i, 1715000000+i,
+			i, i, i, i, i, i, i,
+		)
+	}
+	buf.WriteString(`]}}`)
+	return buf.Bytes()
+}
+
+// BenchmarkV1GetActiveSessionIDs measures parsing a dlg.list reply and collecting its
+// session IDs. The reply is built once outside the loop so its cost isn't measured.
+func BenchmarkV1GetActiveSessionIDs(b *testing.B) {
+	sizes := []int{1000, 10000, 36000}
+	for _, n := range sizes {
+		b.Run(fmt.Sprintf("%dDialogs", n), func(b *testing.B) {
+			response := buildDlgListResponse(n)
+			addr := startMockKamailio(b, response, 0)
+
+			ka := dialMockKamailio(b, addr, 10*time.Second)
+
+			b.SetBytes(int64(len(response)))
+			b.ReportAllocs()
+			for b.Loop() {
+				var sIDs []*sessions.SessionID
+				if err := ka.V1GetActiveSessionIDs("", &sIDs); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/agents/kamagent_test.go
+++ b/agents/kamagent_test.go
@@ -18,12 +18,22 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>
 package agents
 
 import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"regexp"
+	"strconv"
+	"strings"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/cgrates/birpc/context"
 	"github.com/cgrates/cgrates/config"
 	"github.com/cgrates/cgrates/engine"
 	"github.com/cgrates/cgrates/sessions"
+	"github.com/cgrates/cgrates/utils"
 	"github.com/cgrates/kamevapi"
 )
 
@@ -53,6 +63,20 @@ func TestKAReload(t *testing.T) {
 		if conn == nil {
 			t.Errorf("Expected non-nil KamEvapi instance in ka.conns, got nil")
 		}
+	}
+}
+
+func TestKAReloadResizesReplyCh(t *testing.T) {
+	cfg := &config.KamAgentCfg{
+		EvapiConns: []*config.KamConnCfg{{}, {}, {}},
+	}
+	ka := &KamailioAgent{
+		cfg:     cfg,
+		replyCh: make(chan []*sessions.SessionID, 1),
+	}
+	ka.Reload()
+	if cap(ka.replyCh) != len(cfg.EvapiConns) {
+		t.Errorf("expected replyCh cap %d after reload, got %d", len(cfg.EvapiConns), cap(ka.replyCh))
 	}
 }
 
@@ -103,7 +127,174 @@ func TestNewKamailioAgent(t *testing.T) {
 		t.Errorf("Expected conns length = %d, got %d", len(kaCfg.EvapiConns), len(ka.conns))
 	}
 
-	if ka.activeSessionIDs == nil {
-		t.Errorf("Expected activeSessionIDs to be initialized, got nil")
+	if ka.replyCh == nil {
+		t.Error("Expected replyCh to be initialized, got nil")
+	}
+}
+
+func TestKamailioAgentOnDlgListDelivery(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ka := &KamailioAgent{replyCh: make(chan []*sessions.SessionID, 1)}
+		evData := []byte(`{"Jsonrpl_body":{"Result":[]}}`)
+
+		ka.onDlgList(evData, 0)
+		select {
+		case <-ka.replyCh:
+		default:
+			t.Fatal("expected the reply on the channel")
+		}
+
+		ka.replyCh <- nil // fill the buffer
+		done := make(chan struct{})
+		go func() {
+			ka.onDlgList(evData, 0)
+			close(done)
+		}()
+		synctest.Wait()
+		select {
+		case <-done:
+		default:
+			t.Fatal("onDlgList blocked on a full reply channel")
+		}
+	})
+}
+
+func TestKamailioAgentV1GetActiveSessionIDs(t *testing.T) {
+	t.Run("collects replies from the dialog list", func(t *testing.T) {
+		addr := startMockKamailio(t, buildDlgList("call-1", "call-2"), 0)
+		ka := dialMockKamailio(t, addr, time.Second)
+
+		var sIDs []*sessions.SessionID
+		if err := ka.V1GetActiveSessionIDs("", &sIDs); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(sIDs) != 2 {
+			t.Fatalf("expected 2 session IDs, got %d", len(sIDs))
+		}
+		if sIDs[0].OriginID != "call-1;tag" {
+			t.Errorf("expected OriginID call-1;tag, got %q", sIDs[0].OriginID)
+		}
+		if sIDs[0].OriginHost == "" {
+			t.Error("expected OriginHost set from the connection")
+		}
+	})
+
+	t.Run("times out when no reply comes", func(t *testing.T) {
+		addr := startMockKamailio(t, nil, -1)
+		ka := dialMockKamailio(t, addr, 50*time.Millisecond)
+
+		var sIDs []*sessions.SessionID
+		if err := ka.V1GetActiveSessionIDs("", &sIDs); err == nil {
+			t.Fatal("expected timeout error, got nil")
+		}
+	})
+
+	t.Run("returns ErrNoActiveSession when the dialog list is empty", func(t *testing.T) {
+		addr := startMockKamailio(t, buildDlgList(), 0)
+		ka := dialMockKamailio(t, addr, time.Second)
+
+		var sIDs []*sessions.SessionID
+		if err := ka.V1GetActiveSessionIDs("", &sIDs); err != utils.ErrNoActiveSession {
+			t.Fatalf("expected ErrNoActiveSession, got %v", err)
+		}
+	})
+
+	t.Run("drops a stale reply left over from a previous sync", func(t *testing.T) {
+		addr := startMockKamailio(t, buildDlgList("fresh"), 0)
+		ka := dialMockKamailio(t, addr, time.Second)
+		ka.replyCh <- []*sessions.SessionID{{OriginID: "stale"}}
+
+		var sIDs []*sessions.SessionID
+		if err := ka.V1GetActiveSessionIDs("", &sIDs); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(sIDs) != 1 || sIDs[0].OriginID != "fresh;tag" {
+			t.Fatalf("expected only the fresh reply, got %+v", sIDs)
+		}
+	})
+}
+
+func dialMockKamailio(tb testing.TB, addr string, replyTimeout time.Duration) *KamailioAgent {
+	tb.Helper()
+	cfg, err := config.NewDefaultCGRConfig()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	cfg.GeneralCfg().ReplyTimeout = replyTimeout
+	config.SetCgrConfig(cfg)
+	ka := &KamailioAgent{
+		conns:   make([]*kamevapi.KamEvapi, 1),
+		replyCh: make(chan []*sessions.SessionID, 1),
+	}
+	conn, err := kamevapi.NewKamEvapi(addr, 0, 0, 0, utils.FibDuration,
+		map[*regexp.Regexp][]func([]byte, int){kamDlgListRegexp: {ka.onDlgList}}, utils.Logger)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { conn.Disconnect() })
+	ka.conns[0] = conn
+	return ka
+}
+
+// buildDlgList builds a CGR_DLG_LIST reply carrying one dialog per originID.
+func buildDlgList(originIDs ...string) []byte {
+	var b strings.Builder
+	b.WriteString(`{"Event":"CGR_DLG_LIST","Jsonrpl_body":{"result":[`)
+	for i, id := range originIDs {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"call-id":%q,"caller":{"tag":"tag"}}`, id)
+	}
+	b.WriteString(`]}}`)
+	return []byte(b.String())
+}
+
+// startMockKamailio replies to each request with response after delay.
+// A negative delay never replies, to hit the timeout path.
+func startMockKamailio(tb testing.TB, response []byte, delay time.Duration) string {
+	tb.Helper()
+	netstring := fmt.Appendf(nil, "%d:%s,", len(response), response)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { ln.Close() })
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go serveMockKamailio(conn, netstring, delay)
+		}
+	}()
+	return ln.Addr().String()
+}
+
+func serveMockKamailio(conn net.Conn, response []byte, delay time.Duration) {
+	defer conn.Close()
+	rd := bufio.NewReaderSize(conn, 8192)
+	for {
+		lenStr, err := rd.ReadString(':')
+		if err != nil {
+			return
+		}
+		n, err := strconv.Atoi(lenStr[:len(lenStr)-1])
+		if err != nil {
+			return
+		}
+		if _, err := io.CopyN(io.Discard, rd, int64(n+1)); err != nil { // payload + trailing comma
+			return
+		}
+		if delay < 0 {
+			continue // never reply, let the agent time out
+		}
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+		if _, err := conn.Write(response); err != nil {
+			return
+		}
 	}
 }

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -3413,7 +3413,9 @@ func (sS *SessionS) BiRPCv1ProcessEvent(clnt birpc.ClientConnector,
 	return
 }
 
-// BiRPCv1SyncSessions will sync sessions on demand
+// BiRPCv1SyncSessions runs a manual sync. Only to be used when
+// channel_sync_interval is 0, otherwise it can race with the
+// periodic sync and drop live sessions.
 func (sS *SessionS) BiRPCv1SyncSessions(clnt birpc.ClientConnector,
 	ignParam string, reply *string) error {
 	sS.syncSessions()

--- a/sessions/sessions.go
+++ b/sessions/sessions.go
@@ -1287,7 +1287,8 @@ func (sS *SessionS) syncSessions() {
 			defer cancel()
 			var sessionIDs []*SessionID
 			if err := clnt.conn.Call(ctx, utils.SessionSv1GetActiveSessionIDs,
-				"", &sessionIDs); err != nil {
+				"", &sessionIDs); err != nil &&
+				err.Error() != utils.ErrNoActiveSession.Error() {
 				utils.Logger.Warning(fmt.Sprintf(
 					"<%s> failed to retrieve active session IDs: %v", utils.SessionS, err))
 				sessionIDs = nil


### PR DESCRIPTION
V1GetActiveSessionIDs waited a hardcoded 5s for the dlg.list reply, ignoring any reply_timeout above 5s. The sync then timed out and terminated all active sessions.

It now waits for reply_timeout. The reply channel is also buffered and drained each sync so a late reply can't block the handler or be counted in in the next run.