### PR TITLE
ees: drop the go-elasticsearch typed client dependency

### DIFF
--- a/config/config_defaults.go
+++ b/config/config_defaults.go
@@ -677,7 +677,6 @@ const CGRATES_CFG_JSON = `
 
 
 				// Elasticsearch options
-				// "elsCloud": true,			// if true, use cloud ID deployment
 				// "elsApiKey": "",			// base64-encoded token for auth; overrides username/password and service token
 				// "elsUsername": "",			// username for HTTP Basic Authentication
 				// "elsPassword": "",			// password for HTTP Basic Authentication

--- a/config/eescfg.go
+++ b/config/eescfg.go
@@ -171,7 +171,6 @@ type EventExporterOpts struct {
 	ElsCAPath                   *string
 	ElsDiscoverNodesOnStart     *bool
 	ElsDiscoverNodeInterval     *time.Duration
-	ElsCloud                    *bool
 	ElsAPIKey                   *string
 	ElsCertificateFingerprint   *string
 	ElsServiceToken             *string
@@ -282,9 +281,6 @@ func (eeOpts *EventExporterOpts) loadFromJSONCfg(jsnCfg *EventExporterOptsJson) 
 	}
 	if jsnCfg.CSVFieldSeparator != nil {
 		eeOpts.CSVFieldSeparator = jsnCfg.CSVFieldSeparator
-	}
-	if jsnCfg.ElsCloud != nil {
-		eeOpts.ElsCloud = jsnCfg.ElsCloud
 	}
 	if jsnCfg.ElsAPIKey != nil {
 		eeOpts.ElsAPIKey = jsnCfg.ElsAPIKey
@@ -684,10 +680,6 @@ func (eeOpts *EventExporterOpts) Clone() *EventExporterOpts {
 		cln.ElsDiscoverNodeInterval = new(time.Duration)
 		*cln.ElsDiscoverNodeInterval = *eeOpts.ElsDiscoverNodeInterval
 	}
-	if eeOpts.ElsCloud != nil {
-		cln.ElsCloud = new(bool)
-		*cln.ElsCloud = *eeOpts.ElsCloud
-	}
 	if eeOpts.ElsAPIKey != nil {
 		cln.ElsAPIKey = new(string)
 		*cln.ElsAPIKey = *eeOpts.ElsAPIKey
@@ -1049,9 +1041,6 @@ func (optsEes *EventExporterOpts) AsMapInterface() map[string]any {
 	if optsEes.ElsDiscoverNodeInterval != nil {
 		opts[utils.ElsDiscoverNodeInterval] = *optsEes.ElsDiscoverNodeInterval
 	}
-	if optsEes.ElsCloud != nil {
-		opts[utils.ElsCloud] = *optsEes.ElsCloud
-	}
 	if optsEes.ElsAPIKey != nil {
 		opts[utils.ElsAPIKey] = *optsEes.ElsAPIKey
 	}
@@ -1242,7 +1231,6 @@ func (optsEes *EventExporterOpts) AsMapInterface() map[string]any {
 
 type EventExporterOptsJson struct {
 	CSVFieldSeparator           *string           `json:"csvFieldSeparator"`
-	ElsCloud                    *bool             `json:"elsCloud"`
 	ElsAPIKey                   *string           `json:"elsApiKey"`
 	ElsServiceToken             *string           `json:"elsServiceToken"`
 	ElsCertificateFingerprint   *string           `json:"elsCertificateFingerPrint"`

--- a/config/eescfg_test.go
+++ b/config/eescfg_test.go
@@ -1854,7 +1854,6 @@ func TestEescfgNewEventExporterCfg(t *testing.T) {
 		ElsRefresh:                  &str,
 		ElsDiscoverNodesOnStart:     &bl,
 		ElsDiscoverNodeInterval:     &tm,
-		ElsCloud:                    &bl,
 		ElsAPIKey:                   &str,
 		ElsCertificateFingerprint:   &str,
 		ElsServiceToken:             &str,
@@ -1959,7 +1958,6 @@ func TestEescfgloadFromJSONCfg(t *testing.T) {
 	eeOpts := &EventExporterOpts{}
 	jsnCfg := &EventExporterOptsJson{
 		CSVFieldSeparator:           &str,
-		ElsCloud:                    &bl,
 		ElsAPIKey:                   &str,
 		ElsServiceToken:             &str,
 		ElsCertificateFingerprint:   &str,
@@ -2042,7 +2040,6 @@ func TestEescfgloadFromJSONCfg(t *testing.T) {
 		ElsRefresh:                  &str,
 		ElsDiscoverNodesOnStart:     &bl,
 		ElsDiscoverNodeInterval:     &tm,
-		ElsCloud:                    &bl,
 		ElsAPIKey:                   &str,
 		ElsCertificateFingerprint:   &str,
 		ElsServiceToken:             &str,

--- a/data/conf/cgrates/cgrates.json
+++ b/data/conf/cgrates/cgrates.json
@@ -504,7 +504,6 @@
 
 
 // 				// Elasticsearch options
-// 				// "elsCloud":true,                     // whether ExportPath represents a cloud ID deployment
 // 				// "elsApiKey": "",                     // Base64-encoded token for authorization; if set, overrides username/password and service token.
 // 				// "elsUsername":"",                    // Username for HTTP Basic Authentication.
 // 				// "elsPassword":"",			// Password for HTTP Basic Authentication.

--- a/data/conf/samples/ees_elastic/cgrates.json
+++ b/data/conf/samples/ees_elastic/cgrates.json
@@ -51,18 +51,6 @@
 			]
 		},
 		{
-			"id": "els_cloud",
-			"type": "*els",
-			"exportPath": "ELASTIC_DEPLOYMENT",
-			"synchronous": true,
-			"failedPostsDir": "*none",
-			"opts": {
-				"elsIndex": "cdrs",
-				"elsCloud": true,
-				"elsApiKey": "ELASTIC_APIKEY"
-			}
-		},
-		{
 			"id": "els_cluster",
 			"type": "*els",
 			"exportPath": "http://192.168.56.22:9200;http://192.168.56.64:9200",
@@ -83,7 +71,6 @@
 				"elsIndex": "cdrs",
 				"elsUsername": "elastic",
 				// "elsPassword":"",
-				// "elsCloud":true,
 				// "elsApiKey": "",
 				// "elsServiceToken": "",
 				// "elsCertificateFingerPrint": "",

--- a/ees/elastic.go
+++ b/ees/elastic.go
@@ -122,7 +122,9 @@ func (e *ElasticEE) parseRequestOpts() {
 	e.docURL = "http:///" + indexName + "/_doc/"
 
 	q := make(url.Values)
-	q.Set("refresh", "true")
+	if opts.ElsRefresh != nil {
+		q.Set("refresh", *opts.ElsRefresh)
+	}
 	if opts.ElsOpType != nil {
 		q.Set("op_type", *opts.ElsOpType)
 	}

--- a/ees/elastic.go
+++ b/ees/elastic.go
@@ -19,19 +19,22 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>
 package ees
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
 
 	"github.com/elastic/elastic-transport-go/v8/elastictransport"
-	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/optype"
-	"github.com/elastic/go-elasticsearch/v8/typedapi/types/enums/refresh"
 
 	"github.com/cgrates/birpc/context"
 	"github.com/cgrates/cgrates/config"
 	"github.com/cgrates/cgrates/engine"
 	"github.com/cgrates/cgrates/utils"
-	elasticsearch "github.com/elastic/go-elasticsearch/v8"
 )
 
 // ElasticEE implements EventExporter interface for ElasticSearch export.
@@ -41,8 +44,11 @@ type ElasticEE struct {
 	em   *utils.ExporterMetrics
 	reqs *concReq
 
-	client    *elasticsearch.TypedClient
-	clientCfg elasticsearch.Config
+	client    *elastictransport.Client
+	clientCfg elastictransport.Config
+
+	docURL   string // host left empty, the transport fills it in
+	rawQuery string
 }
 
 func NewElasticEE(cfg *config.EventExporterCfg, em *utils.ExporterMetrics) (*ElasticEE, error) {
@@ -54,16 +60,12 @@ func NewElasticEE(cfg *config.EventExporterCfg, em *utils.ExporterMetrics) (*Ela
 	if err := el.parseClientOpts(); err != nil {
 		return nil, err
 	}
+	el.parseRequestOpts()
 	return el, nil
 }
 
 func (e *ElasticEE) parseClientOpts() error {
 	opts := e.cfg.Opts
-	if opts.ElsCloud != nil && *opts.ElsCloud {
-		e.clientCfg.CloudID = e.Cfg().ExportPath
-	} else {
-		e.clientCfg.Addresses = strings.Split(e.Cfg().ExportPath, utils.InfieldSep)
-	}
 	if opts.ElsUsername != nil {
 		e.clientCfg.Username = *opts.ElsUsername
 	}
@@ -86,39 +88,13 @@ func (e *ElasticEE) parseClientOpts() error {
 	if opts.ElsServiceToken != nil {
 		e.clientCfg.ServiceToken = *opts.ElsServiceToken
 	}
-	if opts.ElsDiscoverNodesOnStart != nil {
-		e.clientCfg.DiscoverNodesOnStart = *opts.ElsDiscoverNodesOnStart
-	}
 	if opts.ElsDiscoverNodeInterval != nil {
 		e.clientCfg.DiscoverNodesInterval = *opts.ElsDiscoverNodeInterval
 	}
 	if opts.ElsEnableDebugLogger != nil {
 		e.clientCfg.EnableDebugLogger = *opts.ElsEnableDebugLogger
 	}
-	if loggerType := opts.ElsLogger; loggerType != nil {
-		var logger elastictransport.Logger
-		switch *loggerType {
-		case utils.ElsJson:
-			logger = &elastictransport.JSONLogger{
-				Output:             os.Stdout,
-				EnableRequestBody:  true,
-				EnableResponseBody: true,
-			}
-		case utils.ElsColor:
-			logger = &elastictransport.ColorLogger{
-				Output:             os.Stdout,
-				EnableRequestBody:  true,
-				EnableResponseBody: true,
-			}
-		case utils.ElsText:
-			logger = &elastictransport.TextLogger{
-				Output:             os.Stdout,
-				EnableRequestBody:  true,
-				EnableResponseBody: true,
-			}
-		}
-		e.clientCfg.Logger = logger
-	}
+	e.clientCfg.Logger = elasticLogger(opts.ElsLogger)
 	if opts.ElsCompressRequestBody != nil {
 		e.clientCfg.CompressRequestBody = *opts.ElsCompressRequestBody
 	}
@@ -137,16 +113,78 @@ func (e *ElasticEE) parseClientOpts() error {
 	return nil
 }
 
+func (e *ElasticEE) parseRequestOpts() {
+	opts := e.cfg.Opts
+	indexName := utils.CDRsTBL
+	if opts.ElsIndex != nil {
+		indexName = *opts.ElsIndex
+	}
+	e.docURL = "http:///" + indexName + "/_doc/"
+
+	q := make(url.Values)
+	q.Set("refresh", "true")
+	if opts.ElsOpType != nil {
+		q.Set("op_type", *opts.ElsOpType)
+	}
+	if opts.ElsPipeline != nil {
+		q.Set("pipeline", *opts.ElsPipeline)
+	}
+	if opts.ElsRouting != nil {
+		q.Set("routing", *opts.ElsRouting)
+	}
+	if opts.ElsTimeout != nil {
+		q.Set("timeout", (*opts.ElsTimeout).String())
+	}
+	if opts.ElsWaitForActiveShards != nil {
+		q.Set("wait_for_active_shards", *opts.ElsWaitForActiveShards)
+	}
+	e.rawQuery = q.Encode()
+}
+
+func elasticLogger(loggerType *string) elastictransport.Logger {
+	if loggerType == nil {
+		return nil
+	}
+	switch *loggerType {
+	case utils.ElsJson:
+		return &elastictransport.JSONLogger{Output: os.Stdout, EnableRequestBody: true, EnableResponseBody: true}
+	case utils.ElsColor:
+		return &elastictransport.ColorLogger{Output: os.Stdout, EnableRequestBody: true, EnableResponseBody: true}
+	case utils.ElsText:
+		return &elastictransport.TextLogger{Output: os.Stdout, EnableRequestBody: true, EnableResponseBody: true}
+	}
+	return nil
+}
+
 func (e *ElasticEE) Cfg() *config.EventExporterCfg { return e.cfg }
 
-func (e *ElasticEE) Connect() (err error) {
+func (e *ElasticEE) Connect() error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	if e.client != nil { // check if connection is cached
-		return
+		return nil
 	}
-	e.client, err = elasticsearch.NewTypedClient(e.clientCfg)
-	return
+	addrs := strings.Split(e.Cfg().ExportPath, utils.InfieldSep)
+	urls := make([]*url.URL, len(addrs))
+	for i, addr := range addrs {
+		u, err := url.Parse(addr)
+		if err != nil {
+			return err
+		}
+		urls[i] = u
+	}
+	e.clientCfg.URLs = urls
+	client, err := elastictransport.New(e.clientCfg)
+	if err != nil {
+		return err
+	}
+	if opts := e.cfg.Opts; opts.ElsDiscoverNodesOnStart != nil && *opts.ElsDiscoverNodesOnStart {
+		if err = client.DiscoverNodes(); err != nil {
+			return err
+		}
+	}
+	e.client = client
+	return nil
 }
 
 // ExportEvent implements EventExporter
@@ -161,34 +199,29 @@ func (e *ElasticEE) ExportEvent(ctx *context.Context, event, extraData any) erro
 		return utils.ErrDisconnected
 	}
 
-	// Build and send index request.
+	body, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
 	key := extraData.(string)
-	opts := e.cfg.Opts
-	indexName := utils.CDRsTBL
-	if opts.ElsIndex != nil {
-		indexName = *opts.ElsIndex
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut,
+		e.docURL+url.PathEscape(key), bytes.NewReader(body))
+	if err != nil {
+		return err
 	}
-	req := e.client.Index(indexName).
-		Id(key).
-		Request(event).
-		Refresh(refresh.True)
+	req.Header.Set("Content-Type", "application/json")
+	req.URL.RawQuery = e.rawQuery
 
-	if opts.ElsOpType != nil {
-		req.OpType(optype.OpType{Name: *opts.ElsOpType})
+	resp, err := e.client.Perform(req)
+	if err != nil {
+		return err
 	}
-	if opts.ElsPipeline != nil {
-		req.Pipeline(*opts.ElsPipeline)
+	defer resp.Body.Close()
+	if resp.StatusCode >= http.StatusMultipleChoices {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("elasticsearch index failed: %s: %s", resp.Status, respBody)
 	}
-	if opts.ElsRouting != nil {
-		req.Routing(*opts.ElsRouting)
-	}
-	if opts.ElsTimeout != nil {
-		req.Timeout((*opts.ElsTimeout).String())
-	}
-	if opts.ElsWaitForActiveShards != nil {
-		req.WaitForActiveShards(*opts.ElsWaitForActiveShards)
-	}
-	_, err := req.Do(context.TODO())
+	_, err = io.Copy(io.Discard, resp.Body)
 	return err
 }
 
@@ -209,7 +242,7 @@ func (e *ElasticEE) Close() error {
 
 func (e *ElasticEE) GetMetrics() *utils.ExporterMetrics { return e.em }
 
-func (eEE *ElasticEE) ExtraData(ev *utils.CGREvent) any {
+func (e *ElasticEE) ExtraData(ev *utils.CGREvent) any {
 	return utils.ConcatenatedKey(
 		utils.FirstNonEmpty(engine.MapEvent(ev.APIOpts).GetStringIgnoreErrors(utils.MetaOriginID), utils.GenUUID()),
 		utils.FirstNonEmpty(engine.MapEvent(ev.APIOpts).GetStringIgnoreErrors(utils.MetaRunID), utils.MetaDefault),

--- a/ees/elastic_it_test.go
+++ b/ees/elastic_it_test.go
@@ -24,6 +24,7 @@ package ees
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -37,9 +38,6 @@ import (
 	"github.com/cgrates/cgrates/config"
 	"github.com/cgrates/cgrates/engine"
 	"github.com/cgrates/cgrates/utils"
-	elasticsearch "github.com/elastic/go-elasticsearch/v8"
-	"github.com/elastic/go-elasticsearch/v8/typedapi/core/search"
-	"github.com/elastic/go-elasticsearch/v8/typedapi/types"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -61,9 +59,8 @@ func TestElasticsearchIT(t *testing.T) {
 	// defer fmt.Println(ng.LogBuffer)
 	client, cfg := ng.Run(t)
 
-	// Initialize separate clients for each exporter.
-	esClBasic := initElsClient(t, cfg, "basic")
-	esClFields := initElsClient(t, cfg, "fields")
+	addrBasic := initElsIndex(t, cfg, "basic")
+	addrFields := initElsIndex(t, cfg, "fields")
 
 	n := 2 // number of events to export
 	var wg sync.WaitGroup
@@ -79,12 +76,12 @@ func TestElasticsearchIT(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	verifyElsExports(t, esClBasic, "basic", n, map[string]any{
+	verifyElsExports(t, addrBasic, "basic", n, map[string]any{
 		utils.AccountField: "1001",
 		utils.ToR:          utils.MetaData,
 		utils.RequestType:  utils.MetaPostpaid,
 	})
-	verifyElsExports(t, esClFields, "fields", n, map[string]any{
+	verifyElsExports(t, addrFields, "fields", n, map[string]any{
 		utils.AccountField: "1001",
 		utils.Source:       "test",
 	})
@@ -120,41 +117,34 @@ func exportElsEvent(t *testing.T, client *birpc.Client, exporterSuffix string, i
 //
 // Read all documents (default limit is 10)
 // curl localhost:9200/cdrs_basic/_search
-func verifyElsExports(t *testing.T, client *elasticsearch.TypedClient, exporterType string, n int, expSource map[string]any) {
+func verifyElsExports(t *testing.T, addr, exporterType string, n int, expSource map[string]any) {
 	t.Helper()
-	req := search.Request{
-		Query: &types.Query{MatchAll: &types.MatchAllQuery{}},
-	}
-	if n > 10 && n <= 10_000 {
-		// Return more than the default 10 results limit if needed.
-		// Max limit is 10_000.
-		req.Size = &n
-	}
 	index := fmt.Sprintf("cdrs_%s", exporterType)
-	resp, err := client.Search().
-		Index(index).
-		Request(&req).
-		Do(context.TODO())
+	resp, err := http.Get(fmt.Sprintf("%s/%s/_search?size=%d", addr, index, n))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if hc := len(resp.Hits.Hits); hc != n {
-		t.Fatalf("len(resp.Hits.Hits)=%d, want %d", hc, n)
+	defer resp.Body.Close()
+	var result struct {
+		Hits struct {
+			Hits []elsHit `json:"hits"`
+		} `json:"hits"`
 	}
-	slices.SortFunc(resp.Hits.Hits, func(a, b types.Hit) int {
-		switch {
-		case *a.Id_ < *b.Id_:
-			return -1
-		case *a.Id_ > *b.Id_:
-			return 1
-		}
-		return 0
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	hits := result.Hits.Hits
+	if hc := len(hits); hc != n {
+		t.Fatalf("len(hits)=%d, want %d", hc, n)
+	}
+	slices.SortFunc(hits, func(a, b elsHit) int {
+		return strings.Compare(a.ID, b.ID)
 	})
-	for i, hit := range resp.Hits.Hits {
+	for i, hit := range hits {
 		wantUsage := i + 1
 		wantOriginID := fmt.Sprintf("%s%03d", exporterType, wantUsage)
 
-		if strings.HasPrefix(*hit.Id_, "basic") {
+		if strings.HasPrefix(hit.ID, "basic") {
 			expSource[utils.Usage] = float64(wantUsage)
 		} else {
 			expSource[utils.Usage] = strconv.Itoa(wantUsage)
@@ -165,71 +155,62 @@ func verifyElsExports(t *testing.T, client *elasticsearch.TypedClient, exporterT
 			expSource[utils.OriginID] = wantOriginID
 		}
 		wantDocID := wantOriginID + ":*default"
-		if *hit.Id_ != wantDocID {
-			t.Errorf("hit.Id_ = %s, want %s", *hit.Id_, wantDocID)
+		if hit.ID != wantDocID {
+			t.Errorf("hit.ID = %s, want %s", hit.ID, wantDocID)
 		}
 		var got map[string]any
-		if err := json.Unmarshal(hit.Source_, &got); err != nil {
+		if err := json.Unmarshal(hit.Source, &got); err != nil {
 			t.Error(err)
 		}
 
-		if strings.HasPrefix(*hit.Id_, "fields") {
+		if strings.HasPrefix(hit.ID, "fields") {
 			// Check if @timestamp field exists and has the correct format.
 			// No need to test the exact value.
 			timestamp, has := got["@timestamp"]
 			if !has {
-				t.Fatalf("timestamp missing in document with ID %s", *hit.Id_)
+				t.Fatalf("timestamp missing in document with ID %s", hit.ID)
 			}
 			if _, err := time.Parse(time.RFC3339, utils.IfaceAsString(timestamp)); err != nil {
-				t.Fatalf("failed to parse @timestamp field in document with ID %s", *hit.Id_)
+				t.Fatalf("failed to parse @timestamp field in document with ID %s", hit.ID)
 			}
 			expSource["@timestamp"] = timestamp
 		}
 
 		if diff := cmp.Diff(expSource, got); diff != "" {
-			t.Errorf("SearchAll(index=%q) returned unexpected result (-want +got): \n%s", index, diff)
+			t.Errorf("search(index=%q) returned unexpected result (-want +got): \n%s", index, diff)
 		}
 	}
 }
 
-func initElsClient(t *testing.T, cfg *config.CGRConfig, exporterType string) *elasticsearch.TypedClient {
+type elsHit struct {
+	ID     string          `json:"_id"`
+	Source json.RawMessage `json:"_source"`
+}
+
+func initElsIndex(t *testing.T, cfg *config.CGRConfig, exporterType string) string {
 	eeCfg := cfg.EEsCfg().ExporterCfg(fmt.Sprintf("els_%s", exporterType))
-	tmp := &ElasticEE{
-		cfg: eeCfg,
-	}
-	if err := tmp.parseClientOpts(); err != nil {
-		t.Fatal(err)
-	}
-	client, err := elasticsearch.NewTypedClient(tmp.clientCfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// info, err := client.Info().Do(context.TODO())
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-	// fmt.Println(utils.ToJSON(info))
-
-	// Ensure index is removed at the end. No need to create beforehand, as
-	// it gets created automatically.
 	if eeCfg.Opts.ElsIndex == nil {
 		t.Fatal("elsIndex opt cannot be nil")
 	}
+	addr := strings.Split(eeCfg.ExportPath, utils.InfieldSep)[0]
 	index := *eeCfg.Opts.ElsIndex
 
-	// resp, err := client.Indices.Create(index).Do(context.TODO())
-	// if err != nil {
-	// 	t.Fatal(err)
-	// }
-	// fmt.Println(utils.ToJSON(resp))
-
+	// The index is created automatically on first export. Remove it at the end.
 	t.Cleanup(func() {
-		resp, err := client.Indices.Delete(index).Do(context.TODO())
-		if err != nil || !resp.Acknowledged {
+		req, err := http.NewRequest(http.MethodDelete, addr+"/"+index, nil)
+		if err != nil {
 			t.Errorf("failed to delete index %s: %v", index, err)
+			return
 		}
-
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Errorf("failed to delete index %s: %v", index, err)
+			return
+		}
+		resp.Body.Close()
+		if resp.StatusCode >= http.StatusMultipleChoices {
+			t.Errorf("failed to delete index %s: %s", index, resp.Status)
+		}
 	})
-	return client
+	return addr
 }

--- a/ees/elastic_test.go
+++ b/ees/elastic_test.go
@@ -50,7 +50,7 @@ func TestInitClient(t *testing.T) {
 	if err := ee.parseClientOpts(); err != nil {
 		t.Error(err)
 	}
-	errExpect := `cannot create client: cannot parse url: parse "/\x00": net/url: invalid control character in URL`
+	errExpect := `parse "/\x00": net/url: invalid control character in URL`
 	if err := ee.Connect(); err == nil || err.Error() != errExpect {
 		t.Errorf("Expected %+v \n but got %+v", errExpect, err)
 	}
@@ -69,7 +69,7 @@ func TestElasticExportEventErr(t *testing.T) {
 	if err = eEe.Connect(); err != nil {
 		t.Error(err)
 	}
-	errExpect := `an error happened during the Index query execution: unsupported protocol scheme ""`
+	errExpect := `unsupported protocol scheme ""`
 	if err := eEe.ExportEvent(context.Background(), []byte{}, ""); err == nil || err.Error() != errExpect {
 		t.Errorf("Expected %q but got %q", errExpect, err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/creack/pty v1.1.23
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/elastic/elastic-transport-go/v8 v8.6.0
-	github.com/elastic/go-elasticsearch/v8 v8.15.0
 	github.com/ericlagergren/decimal v0.0.0-20240411145413-00de7ca16731
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-sql-driver/mysql v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,6 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/elastic/elastic-transport-go/v8 v8.6.0 h1:Y2S/FBjx1LlCv5m6pWAF2kDJAHoSjSRSJCApolgfthA=
 github.com/elastic/elastic-transport-go/v8 v8.6.0/go.mod h1:YLHer5cj0csTzNFXoNQ8qhtGY1GTvSqPnKWKaqQE3Hk=
-github.com/elastic/go-elasticsearch/v8 v8.15.0 h1:IZyJhe7t7WI3NEFdcHnf6IJXqpRf+8S8QWLtZYYyBYk=
-github.com/elastic/go-elasticsearch/v8 v8.15.0/go.mod h1:HCON3zj4btpqs2N1jjsAy4a/fiAul+YBP00mBH4xik8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -2945,7 +2945,6 @@ const (
 	ElsCAPath                   = "elsCAPath"
 	ElsDiscoverNodesOnStart     = "elsDiscoverNodesOnStart"
 	ElsDiscoverNodeInterval     = "elsDiscoverNodeInterval"
-	ElsCloud                    = "elsCloud"
 	ElsAPIKey                   = "elsAPIKey"
 	ElsCertificateFingerprint   = "elsCertificateFingerprint"
 	ElsServiceToken             = "elsServiceToken"


### PR DESCRIPTION
go-elasticsearch pulls in 700+ packages just to send one put.
switched to elastic-transport directly.