### PR TITLE
Security: Potential Race Condition in AnalyzerConnector Call Method

### DIFF
--- a/analyzers/connector.go
+++ b/analyzers/connector.go
@@ -47,6 +47,6 @@ type AnalyzerConnector struct {
 func (c *AnalyzerConnector) Call(ctx *context.Context, serviceMethod string, args, reply any) (err error) {
 	sTime := time.Now()
 	err = c.conn.Call(ctx, serviceMethod, args, reply)
-	go c.aS.logTrafic(0, serviceMethod, args, reply, err, c.enc, c.from, c.to, sTime, time.Now())
+	c.aS.logTrafic(0, serviceMethod, args, reply, err, c.enc, c.from, c.to, sTime, time.Now())
 	return
 }


### PR DESCRIPTION
## Summary

Security: Potential Race Condition in AnalyzerConnector Call Method

## Problem

**Severity**: `Medium` | **File**: `analyzers/connector.go:L44`

The `Call` method in `AnalyzerConnector` spawns a goroutine to log traffic without waiting for it to complete. The `go c.aS.logTrafic(...)` call may lead to race conditions or resource leaks if the analyzer service is shut down before the goroutine completes. Additionally, errors from `logTrafic` are silently ignored, which could lead to lost audit logs without detection.

## Solution

Consider using a sync mechanism to ensure log completion, or use a buffered channel/worker pool for logging. At minimum, handle potential errors from logTrafic or ensure the service waits for goroutines on shutdown.

## Changes

- `analyzers/connector.go` (modified)